### PR TITLE
lib-admin doc fixes #3

### DIFF
--- a/docs/libraries/lib-admin.adoc
+++ b/docs/libraries/lib-admin.adoc
@@ -27,35 +27,57 @@ You are now ready to use the API.
 
 == Functions
 
-[[widget-url]]
-=== widgetUrl
+=== getInstallation
 
-Returns the URL for a widget.
+Returns the installation name.
 
 [.lead]
 Parameters
 
-[%header,cols="1%,1%,98%a"]
-[frame="none"]
-[grid="none"]
-|===
-| Name | Kind | Details
-| application | string | Full application name. (f.ex, 'com.enonic.xp.app.main')
-| widget | string | Name of the widget. (f.ex, 'launcher')
-| type | string | Either `server` (server-relative URL) or `absolute`
-| params | object | Custom query parameters to append to the url.
-
-|===
+None
 
 [.lead]
 Returns
 
-*string* : URL of the requested admin tool.
+*string* : The installation name.
 
+[.lead]
+Example
+
+[source,typescript]
+----
+import {getInstallation} from '/lib/xp/admin';
+
+const name = getInstallation();
+----
+
+=== getVersion
+
+Returns the version of the XP installation.
+
+[.lead]
+Parameters
+
+None
+
+[.lead]
+Returns
+
+*string* : The version number of the XP runtime.
+
+[.lead]
+Example
+
+[source,typescript]
+----
+import {getVersion} from '/lib/xp/admin';
+
+const version = getVersion();
+----
 
 === getToolUrl
 
-Returns URL of an admin tool in an application.
+Returns the URL for an admin tool of a specific application.
 
 [.lead]
 Parameters
@@ -64,15 +86,25 @@ Parameters
 [frame="none"]
 [grid="none"]
 |===
-| Name | Kind | Details
-| application | string | Full application name (f.ex, 'com.enonic.app')
-| tool | string | Name of the tool inside an app (f.ex, 'main')
+| Name | Type | Description
+| application | string | Full application name (f.ex, `com.enonic.app.main`).
+| tool | string | Name of the tool inside an app (f.ex, `main`).
 |===
 
 [.lead]
 Returns
 
 *string* : URL of the requested admin tool.
+
+[.lead]
+Example
+
+[source,typescript]
+----
+import {getToolUrl} from '/lib/xp/admin';
+
+const url = getToolUrl('com.enonic.app.main', 'main');
+----
 
 === getHomeToolUrl
 
@@ -81,46 +113,123 @@ Returns the URL for the Home admin tool.
 [.lead]
 Parameters
 
-An object with the following keys and their values:
+[%header,cols="1%,1%,98%a"]
+[frame="none"]
+[grid="none"]
+|===
+| Name | Type | Description
+| params | object | Parameter object. Optional.
+
+[%header,cols="1%,1%,1%,1%,96%a"]
+[frame="topbot"]
+[grid="none"]
+[caption=""]
+.Properties
+!===
+! Name ! Type   ! Attributes ! Default ! Description
+! type ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
+!===
+
+|===
+
+[.lead]
+Returns
+
+*string* : The URL pointing to the Home admin tool.
+
+[.lead]
+Example
+
+[source,typescript]
+----
+import {getHomeToolUrl} from '/lib/xp/admin';
+
+const url = getHomeToolUrl({type: 'absolute'});
+----
+
+=== extensionUrl
+
+Returns the URL for an admin extension.
+
+[.lead]
+Parameters
 
 [%header,cols="1%,1%,98%a"]
 [frame="none"]
 [grid="none"]
 |===
-| Name | Kind | Details
-| type | string | Either `server` (server-relative URL) or `absolute`
+| Name | Type | Description
+| params | object | Parameter object.
+
+[%header,cols="1%,1%,1%,1%,96%a"]
+[frame="topbot"]
+[grid="none"]
+[caption=""]
+.Properties
+!===
+! Name        ! Type   ! Attributes ! Default ! Description
+! application ! string !            !         ! Application key that provides the extension.
+! extension   ! string !            !         ! Name of the extension.
+! type        ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
+! params      ! object ! <optional> !         ! Custom query parameters to append to the URL.
+!===
+
 |===
 
 [.lead]
 Returns
 
-*string* : The URL pointing to the Home Tool
+*string* : URL of the requested extension.
 
-=== getInstallation
+[.lead]
+Example
 
-Returns installation name.
+[source,typescript]
+----
+import {extensionUrl} from '/lib/xp/admin';
+
+const url = extensionUrl({
+    application: 'com.enonic.app.main',
+    extension: 'launcher',
+    type: 'absolute',
+    params: {
+        id: '42'
+    }
+});
+----
+
+=== widgetUrl
+
+WARNING: Deprecated — use <<extensionurl, `extensionUrl`>> instead. This function will be removed in future versions.
+
+Returns the URL for a widget. Equivalent to calling `extensionUrl` with `extension` set to the widget name.
 
 [.lead]
 Parameters
 
-None
+[%header,cols="1%,1%,98%a"]
+[frame="none"]
+[grid="none"]
+|===
+| Name | Type | Description
+| params | object | Parameter object.
+
+[%header,cols="1%,1%,1%,1%,96%a"]
+[frame="topbot"]
+[grid="none"]
+[caption=""]
+.Properties
+!===
+! Name        ! Type   ! Attributes ! Default ! Description
+! application ! string !            !         ! Application key that provides the widget.
+! widget      ! string !            !         ! Name of the widget.
+! type        ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
+! params      ! object ! <optional> !         ! Custom query parameters to append to the URL.
+!===
+
+|===
 
 [.lead]
 Returns
 
-*string* : The installation name
-
-=== getVersion
-
-Returns version of XP installation.
-
-[.lead]
-Parameters
-
-None
-
-
-[.lead]
-Returns
-
-*string* : The version number of the XP runtime.
+*string* : URL of the requested widget.


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-admin.adoc` with the current xp source for `lib-admin` (`modules/lib/lib-admin/src/main/resources/lib/xp/admin.ts` + `AdminLibHelper` / `AdminExtensionUrlHandler`).

## Fixes

- **Added missing function `extensionUrl`** — present in source since the admin-extensions API landed, referenced by `docs/framework/admin-extensions.adoc` (which links to `#extensionurl`), but absent from this page.
- **Marked `widgetUrl` deprecated** — JSDoc on the source has `@deprecated Use extensionUrl instead`; the doc page didn't reflect this. Moved it to the bottom and added a `WARNING` admonition pointing at `extensionUrl`.
- **Fixed `widgetUrl` parameter table** — previously listed `application`, `widget`, `type`, `params` as four top-level args, but the function takes a single `params` object. Restructured to the `params` + `Properties` subtable pattern used by `lib-portal#apiUrl`.
- **Fixed `widgetUrl` return description** — previously said "URL of the requested admin tool"; now "URL of the requested widget".
- **Fixed `getHomeToolUrl` parameter table** — used the `params` + `Properties` subtable pattern, marked `type` as optional with default `server` (matches the JSDoc `[params.type=server]`).
- **Added TypeScript examples** for `getInstallation`, `getVersion`, `getToolUrl`, `getHomeToolUrl`, and `extensionUrl`. The page previously had no per-function examples.
- **Reordered functions** so the deprecated `widgetUrl` sits at the end, after its replacement.
- **Minor wording / column-header normalization** (`Kind`/`Details` → `Type`/`Description` in tables that were already being touched, to match newer lib pages).

Source xp ref: `fix/jsdoc-lib-admin` (the post-audit branch from enonic/xp#11991).