### PR TITLE
lib-auditlog doc fixes #3

### DIFF
--- a/docs/libraries/lib-auditlog.adoc
+++ b/docs/libraries/lib-auditlog.adoc
@@ -47,8 +47,8 @@ An object with the following keys and their values:
 | start | number | <optional> | 0 | Start index (used for paging)
 | count | number | <optional> | 10 | Number of entries to fetch
 | ids | array | <optional> | | Filter by entry ids
-| from | string | <optional> | | Filter by entries earlier than `from`
-| to | string | <optional> | | Filter by entries later than `to`
+| from | string | <optional> | | Filter by entries on or after `from`
+| to | string | <optional> | | Filter by entries on or before `to`
 | type | string | <optional> | | Filter by type
 | source | string | <optional> | | Filter by source
 | users | array | <optional> | | Filter by user keys
@@ -60,7 +60,7 @@ NOTE: All parameters are optional, but you should specify at least one of them. 
 [.lead]
 Returns
 
-*Object* : An array of audit log entries.
+*Object* : Audit log search results, with `total`, `count`, and an array of `hits`.
 
 [.lead]
 Examples
@@ -98,7 +98,7 @@ Parameters
 [.lead]
 Returns
 
-*Object* : Audit log entry as JSON.
+*Object* : Audit log entry as JSON, or `null` if no audit log exists with the given id.
 
 [.lead]
 Examples
@@ -130,7 +130,7 @@ Parameters
 | source | string | <optional> | Log entry source. Defaults to the application ID.
 | user | string | <optional> | Log entry user. Defaults to the user of current context.
 | objects | string[] | <optional> | URIs to objects that relate to this log entry. Defaults to empty array.
-| data | object | <optional> | Custom extra data for the this log entry. Defaults to empty object.
+| data | object | <optional> | Custom extra data for this log entry. Defaults to empty object.
 |===
 
 [.lead]


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-auditlog.adoc` with the current xp source
(`fix/jsdoc-lib-auditlog` branch in `enonic/xp`, post-JSDoc-audit).

Fixes:

- **Signature fix — `find.from` / `find.to`**: descriptions were
  inverted. The JSDoc and the underlying `RangeFilter` define `from` as
  the lower bound (entries on or after) and `to` as the upper bound
  (entries on or before). Updated both rows.
- **Behavioral fix — `find` returns**: claimed "An array of audit log
  entries", but the function actually returns an `AuditLogs` object
  with `total`, `count`, and `hits` (per `auditlog.ts`). Updated the
  Returns line.
- **Behavioral fix — `get` returns**: `get` returns `AuditLog | null`,
  but the doc didn't mention `null`. Added the null case.
- **Style fix — `log.data`**: typo "for the this log entry" → "for
  this log entry".

No coverage gaps: all three exported functions (`find`, `get`, `log`)
were already documented and remain documented.

Source xp ref: `fix/jsdoc-lib-auditlog` (post-audit branch).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>