### PR TITLE
Sync lib-auth doc with xp source #3

### DIFF
--- a/docs/libraries/lib-auth.adoc
+++ b/docs/libraries/lib-auth.adoc
@@ -33,7 +33,7 @@ You are now ready to use the API.
 
 === addMembers
 
-Adds members to a principal (user or role).
+Adds members to a principal (group or role).
 
 [.lead]
 Parameters
@@ -43,8 +43,8 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | Key of the principal to add members to
-| members | string[] | | A list of the new members that should be added to the principal
+| principalKey | string | | Key of the group or role to add members to
+| members | string[] | | Keys of users and groups to add
 |===
 
 [.lead]
@@ -52,29 +52,58 @@ Returns
 
 *void*
 
+[.lead]
+Example
+
+.Add members to a specified principal
+[source,typescript]
+----
+import {addMembers} from '/lib/xp/auth';
+
+addMembers('role:roleId', ['user:system:user1', 'group:system:group-a']);
+----
+
 
 === changePassword
 
-Changes password for a specified user.
+Changes or clears the password for the specified user.
 
 [.lead]
 Parameters
 
 An object with the following keys and their values:
 
-[%header,cols="1%,1%,98%a"]
+[%header,cols="1%,1%,1%,97%a"]
 [frame="none"]
 [grid="none"]
 |===
-| Name | Attributes | Description
-| userKey | | The key of the user to change password for
-| password | | The new password
+| Name | Kind | Attributes | Description
+| userKey | string | | Key of the user to change password for
+| password | string | <optional> | The new password to set. If `null`, the password will be cleared.
 |===
 
 [.lead]
 Returns
 
 *void*
+
+[.lead]
+Example
+
+.Change the password of the current user
+[source,typescript]
+----
+import {getUser, changePassword} from '/lib/xp/auth';
+
+const user = getUser();
+
+if (user) {
+    changePassword({
+        userKey: user.key,
+        password: 'new-secret-password'
+    });
+}
+----
 
 === createGroup
 
@@ -92,8 +121,8 @@ An object with the following keys and their values:
 | Name | Kind | Attributes | Description
 | idProvider | string | | Key for id provider where the group will be created
 | name | string | | Group name
-| displayName | string | | Group display name
-| description | string | | A description of the principal
+| displayName | string | <optional> | Group display name
+| description | string | <optional> | Group description
 |===
 
 [.lead]
@@ -142,9 +171,9 @@ An object with the following keys and their values:
 [grid="none"]
 |===
 | Name | Kind | Attributes | Description
-| name | string | | The name of the role.  The key of the role will be 'role.<name>'.
-| displayName | string | | Role display name
-| description | string | | A description of the role
+| name | string | | The name of the role. The key of the role will be `role:<name>`.
+| displayName | string | <optional> | Role display name
+| description | string | <optional> | Role description
 |===
 
 [.lead]
@@ -194,8 +223,8 @@ An object with the following keys and their values:
 | Name | Kind | Attributes | Description
 | idProvider | string | | Key for id provider where the user will be created
 | name | string | | User login name
-| displayName | string | | User display name
-| email | string | <optional> | Optional user e-mail
+| displayName | string | <optional> | User display name
+| email | string | <optional> | User e-mail
 |===
 
 [.lead]
@@ -246,7 +275,7 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | Key of the principal to delete
+| principalKey | string | | Principal key to delete
 |===
 
 [.lead]
@@ -269,7 +298,10 @@ const deleted = deletePrincipal('user:myIdProvider:userId');
 
 Search for principals matching the specified criteria.
 
-An object with the following keys and their value.  All parameters are optional:
+[.lead]
+Parameters
+
+An object with the following keys and their values. All parameters are optional:
 
 [%header,cols="1%,1%,1%,97%a"]
 [frame="none"]
@@ -278,8 +310,8 @@ An object with the following keys and their value.  All parameters are optional:
 | Name | Kind | Attributes | Description
 | type | string | <optional> | Principal type to look for, one of: 'user', 'group' or 'role'. If not specified all principal types will be included.
 | idProvider | string | <optional> | Key of the id provider to look for. If not specified, all id providers will be included.
-| start | string | <optional> | First principal to return from the search results. It can be used for pagination.
-| count | string | <optional> | A limit on the number of principals to be returned
+| start | number | <optional> | First principal to return from the search results. It can be used for pagination. Default is `0`.
+| count | number | <optional> | A limit on the number of principals to be returned. Default is `10`.
 | name | string | <optional> | Name of the principal to look for
 | searchText | string | <optional> | Text to look for in any principal field.
 |===
@@ -309,14 +341,20 @@ const result = findPrincipals({
 [source,js]
 ----
 ({
-    type: "user",
-    key: "user:system:user1",
-    displayName: "The One And Only",
-    disabled: false,
-    email: "user1@enonic.com",
-    login: "user1",
-    idProvider: "myIdProvider",
-    hasPassword: true
+    total: 1,
+    count: 1,
+    hits: [
+        {
+            type: "user",
+            key: "user:system:user1",
+            displayName: "The One And Only",
+            disabled: false,
+            email: "user1@enonic.com",
+            login: "user1",
+            idProvider: "myIdProvider",
+            hasPassword: true
+        }
+    ]
 })
 ----
 
@@ -324,6 +362,9 @@ const result = findPrincipals({
 === findUsers
 
 Search for users matching the specified query.
+
+[.lead]
+Parameters
 
 An object with the following keys and their values:
 
@@ -333,10 +374,10 @@ An object with the following keys and their values:
 |===
 | Name | Kind | Attributes | Description
 | query | string | | Query expression
-| start | number | <optional> | Optional start index for paging
-| count | number | <optional> | Optional number of users to fetch at a time
-| sort | string | <optional> | Optional sorting expression
-| includeProfile | boolean | <optional> | If set to `true`, a full profile of each user will be included in the result
+| start | number | <optional> | Start index for paging. Default is `0`.
+| count | number | <optional> | Number of users to fetch. Default is `10`.
+| sort | string | <optional> | Sorting expression
+| includeProfile | boolean | <optional> | If set to `true`, a full profile of each user will be included in the result. Default is `false`.
 |===
 
 [.lead]
@@ -430,7 +471,22 @@ None
 [.lead]
 Returns
 
-*object*: An object with all the values in the configuration.
+*object*: An object with all the values in the configuration, or `null` if no configuration is set.
+
+[.lead]
+Example
+
+.Reading a value from the ID provider configuration
+[source,typescript]
+----
+import {getIdProviderConfig} from '/lib/xp/auth';
+
+const config = getIdProviderConfig<{ field?: string }>();
+
+if (config) {
+    log.info('Field value for the current ID provider config = %s', config.field);
+}
+----
 
 === getMembers
 
@@ -444,13 +500,13 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | Principal key to retrieve the members of.
+| principalKey | string | | Principal key (group or role) to retrieve members for
 |===
 
 [.lead]
 Returns
 
-*object[]*: A list of objects for each member of the principal or empty array if none.
+*object[]*: A list of users and groups that are members of the principal, or an empty array if none.
 
 [.lead]
 Example
@@ -500,14 +556,14 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | Principal key to retrieve memberships for
-| transitive | boolean | <optional> | Retrieve transitive memberships.  Considered `false` if not specified
+| principalKey | string | | Principal key (user or group) to retrieve memberships for
+| transitive | boolean | <optional> | Retrieve transitive memberships. Considered `false` if not specified.
 |===
 
 [.lead]
 Returns
 
-*string[]*: A list of the principals that the specified principal is a member of.
+*object[]*: A list of groups and roles that the specified principal is a member of.
 
 [.lead]
 Example
@@ -526,7 +582,7 @@ const result = getMemberships('user:system:user1');
 [{
     type: "role",
     key: "role:system.admin",
-    displayName:"Administrator"
+    displayName: "Administrator"
 }]
 ----
 
@@ -542,10 +598,26 @@ const result = getMemberships('user:system:user1', true);
 [source,js]
 ----
 [
-    "role:system.admin.login",
-    "group:system:content-managers",
-    "role:cms.expert",
-    "role:cms.cm.app"
+    {
+        type: "role",
+        key: "role:system.admin.login",
+        displayName: "Login to administration console"
+    },
+    {
+        type: "group",
+        key: "group:system:content-managers",
+        displayName: "Content Managers"
+    },
+    {
+        type: "role",
+        key: "role:cms.expert",
+        displayName: "CMS Expert"
+    },
+    {
+        type: "role",
+        key: "role:cms.cm.app",
+        displayName: "Content Manager App"
+    }
 ]
 ----
 
@@ -561,13 +633,16 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | Principal key to retrieve memberships for
+| principalKey | string | | Principal key to look for
 |===
 
 [.lead]
 Returns
 
-*object*: The principal as an object.
+*object*: The principal as an object, or `null` if it does not exist.
+
+[.lead]
+Example
 
 .Retrieving the full principal for 'user1'
 [source,typescript]
@@ -606,14 +681,14 @@ An object with the following keys and their values:
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | Principal key to retrieve profile for
-| scope | string | <optional> | Optional scope setting
+| key | string | | Principal key of the user
+| scope | string | <optional> | Scope of the data to retrieve
 |===
 
 [.lead]
 Returns
 
-*object*: Profile data.
+*object*: Profile data, or `null` if the user was not found.
 
 [.lead]
 Example
@@ -639,17 +714,25 @@ const result = getProfile({
 
 === getUser
 
-Returns the logged-in user. If not logged-in, this will return _undefined_ or _null_.
+Returns the logged-in user. If not logged-in, this will return `null`.
 
 [.lead]
 Parameters
 
-None
+An optional object with the following keys and their values:
+
+[%header,cols="1%,1%,1%,97%a"]
+[frame="none"]
+[grid="none"]
+|===
+| Name | Kind | Attributes | Description
+| includeProfile | boolean | <optional> | If set to `true`, the user's profile is included in the result. Default is `false`.
+|===
 
 [.lead]
 Returns
 
-*object*: <<user,`User`>> data.
+*object*: <<user,`User`>> data, or `null` if not logged in.
 
 [.lead]
 Example
@@ -689,7 +772,7 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| role | string | | The role to check for
+| role | string | | Role name to check for
 |===
 
 [.lead]
@@ -705,7 +788,7 @@ Example
 ----
 import {hasRole} from '/lib/xp/auth';
 
-const hasRole = hasRole('system.admin');
+const isAdmin = hasRole('system.admin');
 ----
 
 === login
@@ -797,13 +880,13 @@ An object with the following keys and their values:
 |===
 | Name | Kind | Attributes | Details
 | key | string | | Principal key of the group to modify
-| editor | function | | Group editor function
+| editor | function | | Group editor function to apply to the group
 |===
 
 [.lead]
 Returns
 
-*object*: The updated group.
+*object*: The updated group, or `null` if the group was not found.
 
 [.lead]
 Example
@@ -853,14 +936,17 @@ An object with the following keys and their values:
 |===
 | Name | Kind | Attributes | Details
 | key | string | | Principal key of the user
-| scope | string | <optional> | Optional scope setting
-| editor | function | | Profile editor function
+| scope | string | <optional> | Scope of the data to retrieve and update
+| editor | function | | Profile editor function to apply
 |===
 
 [.lead]
 Returns
 
-*object*: The updated profile.
+*object*: The updated profile, or `null` if the user was not found.
+
+[.lead]
+Example
 
 .Changing a profile
 [source,typescript]
@@ -905,21 +991,24 @@ An object with the following keys and their values:
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | The role key
-| editor | function | | Role editor function
+| key | string | | Principal key of the role to modify
+| editor | function | | Role editor function to apply to the role
 |===
 
 [.lead]
 Returns
 
-*object*: The updated role.
+*object*: The updated role, or `null` if the role was not found.
+
+[.lead]
+Example
 
 .Changing a role
 [source,typescript]
 ----
 import {modifyRole} from '/lib/xp/auth';
 
-// Callback to edit the profile.
+// Callback to edit the role.
 function roleEditor(c) {
     c.displayName = 'Nothing Role';
     c.description = 'This role does not give access to anything!';
@@ -958,21 +1047,24 @@ An object with the following keys and their values:
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | The user key
-| editor | function | | User editor function
+| key | string | | Principal key of the user to modify
+| editor | function | | User editor function to apply to the user
 |===
 
 [.lead]
 Returns
 
-*object*: The updated <<user,`User`>>.
+*object*: The updated <<user,`User`>>, or `null` if the user was not found.
+
+[.lead]
+Example
 
 .Changing a user
 [source,typescript]
 ----
 import {modifyUser} from '/lib/xp/auth';
 
-// Callback to edit the profile.
+// Callback to edit the user.
 function userEditor(c) {
     c.displayName = 'User 1-A';
     c.email = 'user1a@enonic.com';
@@ -1013,8 +1105,8 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Attributes | Details
-| key | string | | The principal key of a group or a role to remove members from
-| members | string[] | | Principal keys to remove as members
+| principalKey | string | | Key of the group or role to remove members from
+| members | string[] | | Keys of the principals to remove
 |===
 
 [.lead]
@@ -1022,10 +1114,15 @@ Returns
 
 *void*
 
-.Remove members from a specified principal.
+[.lead]
+Example
+
+.Remove members from a specified principal
 [source,typescript]
 ----
-authLib.removeMembers('role:roleId', ['user:system:user1', 'group:system:group-a']);
+import {removeMembers} from '/lib/xp/auth';
+
+removeMembers('role:roleId', ['user:system:user1', 'group:system:group-a']);
 ----
 
 == Type Definitions


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-auth.adoc` with the current xp source (branch `fix/jsdoc-lib-auth`, the post-JSDoc-audit head for lib-auth).

All 23 exported functions are documented; no missing coverage. Fixes applied:

**Description / behavior fixes**
- `addMembers`: corrected "(user or role)" → "(group or role)" (matches the source signature, which restricts the first argument to `GroupKey | RoleKey`).
- `changePassword`: noted that the password is optional and that passing `null` clears it.
- `getPrincipal`: parameter description was "retrieve memberships for" — corrected to "look for".
- `getUser`: was documented as taking no parameters, but the function accepts an optional `{ includeProfile?: boolean }`. Added the parameter table.
- `getMemberships` returns: was `*string[]*` and the second sample response showed plain string keys — both wrong. The function returns `(Group | Role)[]`. Updated the type and the second sample response.

**Signature fixes**
- `findPrincipals`: `start` and `count` were typed as `string` — corrected to `number`. Also added their `0` / `10` defaults.
- `findUsers`: added `0` / `10` / `false` defaults for `start`, `count`, `includeProfile`.
- `createUser`: `displayName` was missing the `<optional>` marker.
- `createGroup`: `displayName` and `description` were missing `<optional>` markers; also fixed "description of the principal" → "Group description".
- `createRole`: `displayName` and `description` were missing `<optional>` markers; corrected typo `'role.<name>'` → `` `role:<name>` `` (the actual key format).
- `addMembers`, `deletePrincipal`, `getMembers`, `getMemberships`, `getPrincipal`, `removeMembers`: parameter renamed from `key` to `principalKey` to match the source signature.

**Returns fixes**
- `getPrincipal`, `modifyUser`, `modifyGroup`, `modifyRole`, `modifyProfile`, `getProfile`, `getIdProviderConfig`: returns now mention the `null` case (function returns `null` when the target does not exist).
- `getUser`: returns now mention the `null` case for not-logged-in.

**Examples added**
- `addMembers`, `changePassword`, `getIdProviderConfig` previously had no example block — added TypeScript examples derived from the JS examples in the xp source.

**Example / style fixes**
- `findPrincipals` sample response was a single principal object — corrected to the actual `FindPrincipalsResult` shape (`{ total, count, hits }`).
- `removeMembers` example used an `authLib.removeMembers(...)` call style not consistent with the rest of the page — switched to a named import.
- `hasRole` example declared `const hasRole = hasRole(...)`, shadowing the imported function — renamed the variable to `isAdmin`.
- `modifyRole` / `modifyUser` editors had a stray `// Callback to edit the profile.` comment copy-pasted from `modifyProfile` — corrected.
- Added missing `[.lead] Parameters` / `[.lead] Example` headings on `findPrincipals`, `findUsers`, `getPrincipal`, `modifyUser`, `modifyGroup`, `modifyRole`, `modifyProfile`, `removeMembers` for structural consistency with the rest of the page.

Source xp ref: `fix/jsdoc-lib-auth` (post JSDoc audit head, the most current source of truth per the umbrella issue's instructions).
