### PR TITLE
lib-context doc fixes #3

### DIFF
--- a/docs/libraries/lib-context.adoc
+++ b/docs/libraries/lib-context.adoc
@@ -29,7 +29,7 @@ You are now ready to use the API.
 
 === get
 
-Returns the current context
+Returns the current context.
 
 [.lead]
 Parameters
@@ -39,7 +39,7 @@ None
 [.lead]
 Returns
 
-<<GetContext>>
+*object* : (<<GetContext,`Context`>>) The current context. The `attributes` field is always present (possibly empty); `branch`, `repository`, and `authInfo` are present when set on the calling context.
 
 [.lead]
 Example
@@ -59,13 +59,14 @@ const context = contextLib.get();
   authInfo: {
       user: {                            <1>
           type: "user",
-          key: "user.system.abc",
+          key: "user:system:abc",
           displayName: "A.B.C.",
           disabled: false,
           email: "abc@enonic.com",
           login: "abc",
-          idProvider: "system"
-      }
+          idProvider: "system",
+          hasPassword: true
+      },
       principals: [
           "user:system:abc",
           "role:system.admin",
@@ -80,12 +81,12 @@ const context = contextLib.get();
 }
 ----
 
-<1> The user node will not be returned unless there is a logged-in user.
+<1> The `user` field is only set when a user is logged in.
 
 === run
 
 Runs a function inside a custom context, for instance the one returned by the `get()` function call.
-Commonly used when accessing repositories, or to override current users permissions.
+Commonly used when accessing repositories, or to override the current user's permissions.
 
 [.lead]
 Parameters
@@ -95,29 +96,36 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Details
-| context | object | <<RunContext>> to be used for the scope of the callback function
-| callback | function | Function to execute
+| context | object | <<RunContext,`ContextParams`>> to be used for the scope of the callback function. Any field omitted is inherited from the current context.
+| callback | function | Function to execute. Its return value is propagated as the return value of `run`.
 |===
 
 [.lead]
 Returns
 
-*string* : The result of the execution.
+*any* : Whatever the callback returns.
 
 
 [.lead]
 Example
 
-.Run a simple function in a different context
+.Run a function in a different context
 [source,typescript]
 ----
-// Define the callback to be executed.
-function callback() {
-    return 'Hello from context';
-}
+import {run} from '/lib/xp/context';
 
-// Executes function within a custom context.
-const result = contextLib.run(context, callback);
+const result = run({
+    repository: 'system-repo',
+    branch: 'master',
+    user: {
+        login: 'su',
+        idProvider: 'system'
+    },
+    principals: ['role:system.admin'],
+    attributes: {
+        ignorePublishTimes: true
+    }
+}, () => 'Hello from context');
 ----
 
 .Sample response
@@ -126,11 +134,12 @@ const result = contextLib.run(context, callback);
 "Hello from context"
 ----
 
-== Objects
+== Type Definitions
 
 === GetContext
+[[getcontext]]
 
-The context object is always available within the scope of a request
+The shape of the object returned by `get()`.
 
 .Sample context object
 [source,typescript]
@@ -138,28 +147,34 @@ The context object is always available within the scope of a request
 {
   repository: "some.repo.name", <1>
   branch: "master", <2>
-  authInfo: {
-      user: { <3>
+  authInfo: { <3>
+      user: { <4>
+          type: "user",
+          key: "user:system:mylogin",
+          displayName: "My User",
           login: "mylogin",
-          idProvider: "idprovidername"
+          idProvider: "system",
+          hasPassword: true
       },
-      principals: ["role:system.admin"] <4>
+      principals: ["role:system.admin"] <5>
   },
-  attributes: { <5>
+  attributes: { <6>
      optionalAttributes: "of any kind"
   }
 }
 ----
 
-<1> *repository* (_string_) Repository context.
-<2> *branch* (_string_) Branch context.
-<3> *user* (_object_) Specify a valid user/ID provider combination
-<4> *principals* (_object_) Roles or group principals applicable for current user
-<5> *attributes* (_object_) custom attributes image:xp-780.svg[XP 7.8.0,opts=inline]
+<1> *repository* (_string_, optional) Repository context.
+<2> *branch* (_string_, optional) Branch context.
+<3> *authInfo* (_object_, optional) Authentication information for the current context.
+<4> *user* (_object_, optional) The currently authenticated user. Omitted when no user is logged in.
+<5> *principals* (_string[]_, optional) Principal keys (users, groups, and roles) attached to the authentication info.
+<6> *attributes* (_object_) Custom attributes set on the context. Always present; may be empty. Only values of type `number`, `string`, `boolean`, or plain `object` are serialized.
 
 === RunContext
 [[runcontext]]
-The context object is always available within the scope of a request
+
+The parameter object passed to `run()`. Any field omitted is inherited from the calling context.
 
 .Sample context object
 [source,typescript]
@@ -169,7 +184,7 @@ The context object is always available within the scope of a request
   branch: "master", <2>
   user: { <3>
       login: "mylogin",
-      idProvider: "idprovidername"
+      idProvider: "system"
   },
   principals: ["role:system.admin"], <4>
   attributes: { <5>
@@ -178,8 +193,8 @@ The context object is always available within the scope of a request
 }
 ----
 
-<1> *repository* (_string_) Repository context.
-<2> *branch* (_string_) Branch context.
-<3> *user* (_object_) Specify a valid user/idprovider combination
-<4> *principals* (_object_) Roles or group principals applicable for current user
-<5> *attributes* (_object_) custom attributes image:xp-780.svg[XP 7.8.0,opts=inline]
+<1> *repository* (_string_, optional) Repository to run the callback in. Defaults to the current repository.
+<2> *branch* (_string_, optional) Branch to run the callback in. Defaults to the current branch.
+<3> *user* (_object_, optional) User to run the callback as. `login` is required; `idProvider` defaults to the system id provider when omitted.
+<4> *principals* (_string[]_, optional) Additional principal keys (users, groups, and roles) to attach to the authentication info for the duration of the callback.
+<5> *attributes* (_object_, optional) Additional context attributes. Only values of type `number`, `string`, `boolean`, or plain `object` are supported.


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-context.adoc` with the current xp source for `lib-context` (using the post-audit branch `fix/jsdoc-lib-context`, which is internally consistent with the Java handler).

## Corrections

**Signature fix**

- `run()` return type: doc claimed `*string* : The result of the execution.`, but the source signature is `<T>(context, callback: () => T): T` — `run` returns whatever the callback returns. Updated to `*any* : Whatever the callback returns.`

**Behavioral / signature fidelity**

- `get()` returns: documented that `attributes` is always present (possibly empty) while `branch`, `repository`, and `authInfo` are only present when set on the calling context (matches `ContextMapper.serialize`).
- Documented that context `attributes` only serialize values of type `number`, `string`, `boolean`, or plain `object` (`ContextMapper.canBeSerialized`).
- `RunContext` (`ContextParams`): documented field-by-field optionality and inheritance from the calling context, replacing the misleading prose "The context object is always available within the scope of a request" (true for `get`, but `RunContext` is an input parameter, not an ambient object).

**Example fixes**

- `GetContext` "Sample context object" had a `user` shaped like the input `ContextUserParams` (`{login, idProvider}`). Replaced with the real `User` shape returned by the Java handler: `type`, `key`, `displayName`, `login`, `idProvider`, `hasPassword`.
- `get()` "Sample response": fixed invalid principal key `user.system.abc` -> `user:system:abc` (matches `UserKey` type), added missing comma after the `user` object, and added `hasPassword` to match the `User` interface.
- `run()` example used an undeclared `context` variable. Replaced with a self-contained, runnable TypeScript example aligned with `examples/context/run.js`.

**Style**

- Renamed the second-level section `Objects` to `Type Definitions`, matching sibling pages (e.g. `lib-task.adoc`).
- Removed references to the missing `xp-780.svg` image asset (not present in this repo).
- Added a stable `[[getcontext]]` anchor (parallel to the existing `[[runcontext]]`).

The cross-reference target `<<lib-context#runcontext, ...>>` used by `lib-auth.adoc`, `lib-app.adoc`, and `lib-schema.adoc` is preserved.

Source xp ref: `fix/jsdoc-lib-context` (post-JSDoc audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)