### PR TITLE
Sync lib-event doc with xp source #3

### DIFF
--- a/docs/libraries/lib-event.adoc
+++ b/docs/libraries/lib-event.adoc
@@ -34,35 +34,52 @@ For more details, check out the <<lib-node#events, Node library>>, <<lib-repo#ev
 
 === listener
 
-Creates an event listener
+Registers an event listener that fires for events whose type matches the given pattern.
 
 [.lead]
 Parameters
 
 An object with the following keys and their values:
 
-[%header,cols="1%,1%,98%a"]
+[%header,cols="1%,1%,1%,97%a"]
 [frame="none"]
 [grid="none"]
 |===
-| Name | Kind | Details
-| type | string | Works like a Java Pattern, with two key differences: `.` is treated as a literal dot, not a wildcard. `\*` acts as `.*`, matching any sequence of characters.
-| callback | function | Callback event listener
-| localOnly | boolean | Local events only (default to false)
+| Name | Type | Attributes | Description
+| type | string | | Event type pattern. Works like a Java pattern, with two key differences: `.` is treated as a literal dot (not a wildcard), and `*` acts as `.*`, matching any sequence of characters.
+| callback | function | | Function invoked for each matching event. Receives a single event argument with the shape described in <<#enonic-event,Event object>>.
+| localOnly | boolean | <optional> | When `true`, only events originating on the current node are delivered. Defaults to `false`.
 |===
+
+[#enonic-event]
+.Event object passed to the callback
+[%header,cols="1%,1%,98%a"]
+[frame="topbot"]
+[grid="none"]
+[caption=""]
+!===
+! Name ! Type ! Description
+! type ! string ! Event type, for example `node.pushed` or `custom.myEvent`.
+! timestamp ! number ! Time the event was published, in milliseconds since the epoch.
+! localOrigin ! boolean ! `true` if the event was published on the current node, `false` if it was received from another cluster node.
+! distributed ! boolean ! `true` if the event was distributed across the cluster.
+! data ! object ! Event payload. Shape depends on the event `type`; for built-in node events, see <<lib-node#events, Node library>>.
+!===
 
 [.lead]
 Returns
 
-`null`
+*void*
 
 [.lead]
 Example
 
-.Adding a listener that logs the event
+.Adding a listener that logs every node event
 [source,typescript]
 ----
-eventLib.listener({
+import {listener} from '/lib/xp/event';
+
+listener({
     type: 'node.*',
     localOnly: false,
     callback: (event) => {
@@ -73,27 +90,27 @@ eventLib.listener({
 
 === send
 
-Sends a custom event.  All custom events are prefixed with `custom.`.
+Sends a custom event. The supplied `type` is automatically prefixed with `custom.` before the event is published.
 
 [.lead]
 Parameters
 
 An object with the following keys and their values:
 
-[%header,cols="1%,1%,98%a"]
+[%header,cols="1%,1%,1%,97%a"]
 [frame="none"]
 [grid="none"]
 |===
-| Name | Kind | Details
-| type | string | Event type
-| distributed | boolean | `true` if it should be distributed in cluster
-| data| object | Additional data for event.
+| Name | Type | Attributes | Description
+| type | string | | Event type. Will be published as `custom.<type>`.
+| distributed | boolean | <optional> | When `true`, the event is broadcast to every node in the cluster. Defaults to `false`.
+| data | object | <optional> | Additional data to attach to the event payload.
 |===
 
 [.lead]
 Returns
 
-`null`
+*void*
 
 [.lead]
 Example
@@ -101,7 +118,9 @@ Example
 .Send a custom event into the system
 [source,typescript]
 ----
-eventLib.send({
+import {send} from '/lib/xp/event';
+
+send({
     type: 'myEvent',
     distributed: false,
     data: {


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-event.adoc` with the current xp source for `lib-event` (branch `fix/jsdoc-lib-event`, post-JSDoc-audit).

## Corrections

- **Return type fix:** Both `listener` and `send` returned `null` in the doc; the TS declarations and Java handlers return `void`. Replaced with `*void*` (consistent with neighbouring lib pages such as lib-task and lib-websocket).
- **Optionality / defaults:** Added an `Attributes` column to the parameter tables and explicitly marked `localOnly`, `distributed`, and `data` as `<optional>` with their defaults (`false` / `false` / no value), matching the JSDoc audit landing in xp.
- **Missing reference info — event payload shape:** The `listener` callback receives an `EnonicEvent` object (`type`, `timestamp`, `localOrigin`, `distributed`, `data`) per the TS declaration in `event.ts`. Added a properties table describing each field, with `timestamp` clarified as ms since epoch (per `Event.java` using `System.currentTimeMillis()`).
- **Header consistency:** Renamed parameter columns from `Kind | Details` to `Type | Description` to match the convention used across the other library pages.
- **Example imports:** Switched examples from the `eventLib.listener(...)` / `eventLib.send(...)` form to named imports (`import {listener} from '/lib/xp/event'`), matching the style used in lib-cluster, lib-task, lib-websocket, etc.
- **Description tightening:** Slightly expanded the function blurbs (`Registers an event listener...`, `Sends a custom event. The supplied type is automatically prefixed with custom.`) to better reflect what the Java handler actually does.

Source xp ref: `fix/jsdoc-lib-event` (post-audit branch for enonic/xp#11991).