### PR TITLE
lib-export doc fixes #3

### DIFF
--- a/docs/libraries/lib-export.adoc
+++ b/docs/libraries/lib-export.adoc
@@ -65,13 +65,25 @@ Examples
 import {exportNodes} from '/lib/xp/export';
 
 // Export content nodes.
-const exportNodes = exportNodes({
+const result = exportNodes({
     sourceNodePath: '/content',
     exportName: 'export-1',
-    nodeExported: (i) => {
+    nodeExported: (i: number) => {
     },
-    nodeResolved: (i) => {
+    nodeResolved: (i: number) => {
     }
+});
+----
+
+[source,typescript]
+----
+import {exportNodes} from '/lib/xp/export';
+
+// Export content nodes with a custom batch size.
+const result = exportNodes({
+    sourceNodePath: '/content',
+    exportName: 'export-batch',
+    batchSize: 25
 });
 ----
 
@@ -111,12 +123,12 @@ An object with the following keys and their values:
 
 | source | string or object | | | Either name of nodes-export located in exports directory or application resource key
 | targetNodePath | string | | | Target path for imported nodes
-| xslt | string or object  | <optional>| true | XSLT file name in exports directory or application resource key. Used for XSLT transformation
+| xslt | string or object  | <optional>| | XSLT file name in exports directory or application resource key. Used for XSLT transformation
 | xsltParams | object  | <optional>| | Parameters used in XSLT transformation
 | includeNodeIds | boolean | <optional>| false | Set to `true` to use node IDs from the import, `false` to generate new node IDs
 | includePermissions | boolean | <optional>| false | Set to `true` to overwrite Node permissions with permissions from the import, `false` to merge permissions with new parent permissions
 | versionAttributes | object | <optional>| | Optional attributes attached to the node version of every imported node
-| nodeResolved | function | <optional>| | A function to be called during import with number of nodes imported since last call
+| nodeResolved | function | <optional>| | A function to be called before import starts with number of nodes to import
 | nodeImported | function | <optional>| | A function to be called during import with number of nodes imported since last call
 | nodeSkipped | function | <optional>| | A function to be called during import with number of nodes skipped since last call
 |===
@@ -142,11 +154,11 @@ const importedNodes = importNodes({
     xsltParams: {k: 'v'},
     includeNodeIds: true,
     includePermissions: true,
-    nodeImported: (i) => {
+    nodeImported: (i: number) => {
     },
-    nodeResolved: (i) => {
+    nodeResolved: (i: number) => {
     },
-    nodeSkipped: (i) => {
+    nodeSkipped: (i: number) => {
     }
 });
 ----
@@ -172,6 +184,7 @@ const expected = {
     updatedNodes: [
         '/updated'
     ],
+    skippedNodes: [],
     importedBinaries: [
         'binaryPath [ref]'
     ],


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-export.adoc` with the current xp source (audit branch `fix/jsdoc-lib-export`).

Corrections:
- **Example fix (`exportNodes`):** the result variable was named `exportNodes`, shadowing the imported function (TypeScript duplicate-identifier error). Renamed to `result`.
- **Example fix (`exportNodes`):** added explicit `(i: number)` types to the `nodeExported` / `nodeResolved` callbacks (implicit `any` is invalid under strict TS).
- **Example added (`exportNodes`):** new example showing the `batchSize` parameter in use, mirroring the xp `exportNodesWithBatchSize.js` example file.
- **Signature fix (`importNodes.xslt`):** removed bogus `Default: true` value — `xslt` has no default; if omitted, no XSLT transformation is applied.
- **Behavioral fix (`importNodes.nodeResolved`):** description was a copy of `nodeImported`. Per the JSDoc, `nodeResolved` is called *before* import starts with the total number of nodes to import, not during with the number imported.
- **Example fix (`importNodes`):** added explicit `(i: number)` types to the three callback parameters.
- **Example fix (`importNodes`):** added missing `skippedNodes: []` field to the expected-result example so it matches the shape returned by `NodeImportResultMapper`.

Source xp ref: `fix/jsdoc-lib-export` (post-JSDoc audit, enonic/xp#11991).