### PR TITLE
Sync lib-grid doc with xp source #3

### DIFF
--- a/docs/libraries/lib-grid.adoc
+++ b/docs/libraries/lib-grid.adoc
@@ -5,7 +5,7 @@
 
 image:xp-7100.svg[XP 7.10.0,opts=inline] This API provides functions that enable sharing data across all applications and cluster nodes.
 
-NOTE: Due to distributed nature of `SharedMap` not all value types can be used. Strings, numbers, and pure JSON objects are supported. There is no runtime check for type compatibility due to performance reasons. Developers are themselves responsible for NOT modifying shared objects (keys and values) in place.
+NOTE: Due to distributed nature of `SharedMap` not all value types can be used. Strings, numbers, booleans, and pure JSON objects are supported. There is no runtime check for type compatibility due to performance reasons. Developers are themselves responsible for NOT modifying shared objects (keys and values) in place.
 
 == Usage
 
@@ -40,15 +40,14 @@ Parameters
 [frame="none"]
 [grid="none"]
 |===
-| Name | Kind   | Description
-| key  | string | map identifier
+| Name  | Kind   | Description
+| mapId | string | Map identifier.
 |===
 
 [.lead]
 Returns
 
-*SharedMap* :
-JS object.
+*SharedMap* : An instance of `SharedMap` bound to the given identifier.
 
 [source,typescript]
 ----
@@ -61,7 +60,7 @@ const sharedMap = getMap('mapId');
 
 === set
 
-Puts an entry into a SharedMap with a given time to live (TTL).
+Puts an entry into a SharedMap with a given time to live (TTL). If `value` is `null`, the existing entry for that key is removed.
 
 [.lead]
 Parameters
@@ -71,28 +70,28 @@ Parameters
 [grid="none"]
 |===
 | Name  | Kind   | Description
-| key   | string | Key of the entry
-| value | string\|number\|boolean\|JSON\|null | Value of the entry
-| ttlSeconds | number    | Maximum time (in seconds) for this entry to remain in the map. 0 means infinite, a negative value means default TTL setting of the map provider (for instance, Hazelcast) or infinite if map provider doesn't have own TTL setting.
+| key   | string | Key of the entry.
+| value | string\|number\|boolean\|JSON\|null | Value of the entry. Passing `null` removes the existing entry.
+| ttlSeconds | number | Optional. Maximum time (in seconds) for this entry to remain in the map. `0` means infinite; a negative value means the default TTL of the map provider (for instance, Hazelcast) or infinite if the provider has no own TTL setting.
 |===
 
 [source,typescript]
 ----
 import gridLib from '/lib/xp/grid';
 
-const sharedMap = gridLib.getMap('mapId');
+const sharedMap = gridLib.getMap<{ greeting: string }>('mapId');
 
 sharedMap.set({
-  key: 'key',
-  value: 'value',
-  ttlSeconds: 2 * 60 * 1000
+  key: 'greeting',
+  value: 'hello',
+  ttlSeconds: 2 * 60
 });
 ----
 
 
 === get
 
-Returns a value to which the specified key is mapped, or `null` if this map contains no mapping for the key.
+Returns the value to which the specified key is mapped, or `null` if the map contains no mapping for the key.
 
 [.lead]
 Parameters
@@ -102,8 +101,13 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind   | Description
-| key  | string | The key for a value to be returned
+| key  | string | The key whose associated value is to be returned.
 |===
+
+[.lead]
+Returns
+
+*string\|number\|boolean\|JSON\|null* : The value mapped to the given key, or `null` if no mapping exists.
 
 [source,typescript]
 ----
@@ -116,7 +120,7 @@ const value = sharedMap.get('key');
 
 === delete
 
-Removes entry for the specified key if it is present in the map.
+Removes the entry for the specified key if it is present in the map.
 
 [.lead]
 Parameters
@@ -126,7 +130,7 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind   | Description
-| key  | string | The key for a value to be removed
+| key  | string | The key whose associated value is to be removed.
 |===
 
 [source,typescript]
@@ -151,21 +155,24 @@ Parameters
 |===
 | Name       | Kind      | Description
 | key        | string    | Key of the entry.
-| func       | function  | Mapping function that accepts the existing mapped value (or null, if there is no associated mapping). A value returned by the function will replace the existing mapped value for the specified key. If the returned value is null then the entry will be removed from the map.
-| ttlSeconds | number    | Maximum time (in seconds) for this entry to remain in the map. 0 means infinite, a negative value means default TTL setting of the map provider (for instance, Hazelcast) or infinite if map provider doesn't have own TTL setting.
+| func       | function  | Mapping function that accepts the existing mapped value (or `null`, if there is no associated mapping). The value it returns replaces the existing mapped value for the specified key. If the returned value is `null`, the entry is removed from the map.
+| ttlSeconds | number    | Optional. Maximum time (in seconds) for this entry to remain in the map. `0` means infinite; a negative value means the default TTL of the map provider (for instance, Hazelcast) or infinite if the provider has no own TTL setting.
 |===
+
+[.lead]
+Returns
+
+*string\|number\|boolean\|JSON\|null* : The new value mapped to the key, or `null` if the entry was removed (because `func` returned `null`).
 
 [source,typescript]
 ----
 import gridLib from '/lib/xp/grid';
 
-const sharedMap = gridLib.getMap('mapId');
+const sharedMap = gridLib.getMap<{ counter: number }>('mapId');
 
-let newValue = sharedMap.modify({
-  key: 'key',
-  func: (oldValue) =>{
-      return oldValue + 1;
-  },
-  ttlSeconds: 2 * 60 * 1000
+const newValue = sharedMap.modify({
+  key: 'counter',
+  func: (oldValue) => (oldValue ?? 0) + 1,
+  ttlSeconds: 2 * 60
 });
 ----


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-grid.adoc` with the current xp source for `lib-grid` (post-JSDoc-audit branch `fix/jsdoc-lib-grid`, commit `993efb5c32`).

## Fixes

- **Behavioral fidelity:** Added `booleans` to the supported value-types NOTE — `SharedMapValueType` is `string | number | boolean | object | null`, but the doc only listed strings, numbers, and JSON objects. (Mirrors the recent xp-side fix in #11991.)
- **Signature fix — `getMap`:** parameter is `mapId` per the source signature, not `key`. Updated the parameter table and tightened the Returns description (was a vague "JS object").
- **Signature fix — `set`:** marked `ttlSeconds` as optional and documented the null-value behavior (passing `null` removes the entry), per the JSDoc on `SharedMapImpl.set`.
- **Coverage — added missing Returns sections** for `get` and `modify` (both can return `null`; `modify`'s `null` case is when `func` returns `null` and the entry is removed — matches the recent xp fix that corrected `modify`'s return type from `Map[Key]` to `Map[Key] | null`).
- **Signature fix — `modify`:** marked `ttlSeconds` as optional.
- **Example fixes:** TTL examples used `2 * 60 * 1000` (~33 hours) but `ttlSeconds` is in seconds — corrected to `2 * 60` for "2 minutes". The `modify` example's `func` did `oldValue + 1` even though the source documents `oldValue` as possibly `null`; switched to `(oldValue ?? 0) + 1`. Added `getMap<…>` generics on the SharedMap examples so the TS examples actually typecheck.
- **Style polish:** standardized `key`/`mapId` parameter descriptions to match the JSDoc wording ("the key whose associated value is to be returned/removed").

Source xp ref: branch `fix/jsdoc-lib-grid` (post-JSDoc audit), commit `993efb5c32`.