### PR TITLE
lib-i18n doc fixes #3

### DIFF
--- a/docs/libraries/lib-i18n.adoc
+++ b/docs/libraries/lib-i18n.adoc
@@ -61,30 +61,30 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Details
-| locale | string \| string[] | A string-representation of a locale, or an array of locales in preferred order.  Pass in an empty array for default locale.
-| bundles | string[] | Required list of bundle names. Bundle names are specified as paths, relative to the `src/main/resources/` folder.
+| locale | string \| string[] | A string-representation of a locale, or an array of locales in preferred order. Pass in an empty array to use the site language.
+| bundles | string[] | Optional list of bundle names. Bundle names are specified as paths, relative to the `src/main/resources/` folder.
 |===
 
 [.lead]
 Returns
 
-An object with all phrases
+*object* : An object whose keys are the phrase keys and whose values are the localized strings.
 
 [.lead]
 Example
 
-.Getting the current context
+.Get all phrases for a locale
 [source,typescript]
 ----
-const phrasesEs = i18nLib.getPhrases('es', ['i18n/phrases'])
+const phrasesEs = i18nLib.getPhrases('es', ['i18n/phrases']);
 ----
 
 .Sample response
 [source,typescript]
 ----
 {
-  action.preview:"Vista Previa",
-  notify.process.failed:"Error al procesar: {0}."
+    "action.preview": "Vista Previa",
+    "notify.process.failed": "Error al procesar: {0}."
 }
 ----
 
@@ -100,21 +100,21 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Details
-| bundles | string[] | Required list of bundle names. Bundle names are specified as paths, relative to the `src/main/resources` folder.
+| bundles | string[] | Optional list of bundle names. Bundle names are specified as paths, relative to the `src/main/resources` folder.
 |===
 
 [.lead]
 Returns
 
-An array with all locales
+*string[]* : Sorted array of supported locale codes (as language tags).
 
 [.lead]
 Example
 
-.Getting the current context
+.Get the supported locales for a bundle
 [source,typescript]
 ----
-const locales = i18nLib.getSupportedLocales(['i18n/phrases'])
+const locales = i18nLib.getSupportedLocales(['i18n/phrases']);
 ----
 
 .Sample response
@@ -125,9 +125,11 @@ const locales = i18nLib.getSupportedLocales(['i18n/phrases'])
 
 === localize
 
-Localizes a phrase by searching through the list of passed in locales in the given order, to find a translation for the phrase-key.
-If no translation is found, the default phrase will be used. Some phrases will have placeholders (`{0}`, `{1}` etc) for values that may be inserted
-into the phrase.  These must be provided in the function call for those phrases.
+Localizes a phrase by searching through the list of passed-in locales in the given order to find a translation for the phrase key.
+If no translation is found, the default phrase will be used. Some phrases will have placeholders (`{0}`, `{1}` etc.) for values that may be inserted
+into the phrase. These must be provided in the function call for those phrases.
+
+The function takes a single `params` object with the following properties:
 
 [.lead]
 Parameters
@@ -137,34 +139,47 @@ Parameters
 [grid="none"]
 |===
 | Name | Kind | Details
-| key | string | The phrase key
-| locale | string \| string[] | A string-representation of a locale, or an array of locales in preferred order. If the locale is not set, the site language is used.
-| values | string[] | Optional placeholder values
-| bundles | string[] | Optional list of bundle names
+| key | string | The phrase key. Required.
+| locale | string \| string[] | Optional. A string-representation of a locale, or an array of locales in preferred order. If not set, the site language is used.
+| values | string[] | Optional placeholder values.
+| bundles | string[] | Optional list of bundle names.
+| fallbackMessage | string | Optional fallback message returned when the phrase is not found. Defaults to `"NOT_TRANSLATED"`.
 |===
 
 [.lead]
 Returns
 
-The localized string
+*string* : The localized string, or the fallback message if the phrase is not found.
 
 [.lead]
 Example
 
-.Localize a message with a placeholder.
+.Localize a message with a placeholder
 [source,typescript]
 ----
 import {localize} from '/lib/xp/i18n';
 
-const message2 = localize({
+const message = localize({
     key: 'notify.process.failed',
     locale: 'es',
-    values: ["StaleConnectionException"]
+    values: ['StaleConnectionException']
 });
 ----
 
 .Sample response
 [source,typescript]
 ----
-Error al procesar: "StaleConnectionException".
+Error al procesar: StaleConnectionException.
+----
+
+.Localize with a custom fallback
+[source,typescript]
+----
+import {localize} from '/lib/xp/i18n';
+
+const message = localize({
+    key: 'action.preview',
+    locale: ['es', 'en'],
+    fallbackMessage: '(missing translation)'
+});
 ----


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-i18n.adoc` with the current xp source for `lib-i18n` (master HEAD; no `fix/jsdoc-lib-i18n` branch exists).

Fixes:

- **localize** — added the missing `fallbackMessage` parameter (defaults to `"NOT_TRANSLATED"`), which is part of `LocalizeParams` in the source but absent from the docs.
- **localize** — corrected `locale` from required to optional (the source falls back to the site language).
- **localize** — `Returns` now notes the fallback path, matching the Java handler's `requireNonNullElse(localizedMessage, fallbackMessage)` behavior.
- **localize** — added a second example demonstrating `fallbackMessage`; cleaned up double-spaces and a stray quoted placeholder in the original example output.
- **getPhrases** — corrected `bundles` from "Required" to "Optional" (the TS signature is `bundles?: string[]`).
- **getPhrases** — fixed the `Sample response` to be valid TypeScript (keys with dots now quoted, comma-separation made explicit).
- **getPhrases** — clarified that an empty `locale` falls back to the site language.
- **getSupportedLocales** — corrected `bundles` from "Required" to "Optional".
- **getSupportedLocales** — replaced the stray "Getting the current context" example caption (a copy-paste leftover from `lib-context`) with an apt one; noted that the returned array is sorted by language tag.
- Style: `Returns` sections now use the `*type* : description` form used in `lib-app` / `lib-cluster`.

Source xp ref: `master` (no `fix/jsdoc-lib-i18n` branch exists for this lib).