### PR TITLE
Sync lib-mail doc with xp source #3

### DIFF
--- a/docs/libraries/lib-mail.adoc
+++ b/docs/libraries/lib-mail.adoc
@@ -42,7 +42,7 @@ The `from` parameter supports the <<getDefaultFromEmail,default _from_ email>> s
 If the email address is not specified in angle brackets (e.g., `Some Name <>` or `<>`), the default _from_ email address is used.
 However, an error is thrown if the default _from_ email is not set.
 
-The parameters `to`, `cc` and `bcc` can be passed as a single string or as an array of strings, if there are multiple addresses to specify.
+The parameters `from`, `to`, `cc`, `bcc` and `replyTo` can be passed as a single string or as an array of strings, if there are multiple addresses to specify.
 
 The content-type of the email can be specified by using the `contentType` parameter. See example below for sending a message with an HTML body.
 
@@ -56,15 +56,15 @@ An object with the following parameters:
 [grid="none"]
 |===
 | Name | Kind | Details
-| from | string | E-mail address and optionally name of message sender
+| from | string \| string[] | E-mail address(es) and optionally name(s) of the message sender
 | to | string \| string[] | E-mail address(es) and optionally name(s) of the message’s recipient(s)
 | cc | string \| string[] | Optional list of carbon copy e-mail address(es)
 | bcc | string \| string[] | Optional list of blind carbon copy e-mail address(es)
-| replyTo | string | Optional alternative e-mail address for replies
+| replyTo | string \| string[] | Optional alternative e-mail address(es) for replies
 | subject | string | Subject line of the message
 | body | string | Text content of the message
 | contentType | string | Optional content type of the message body
-| headers | string | Optional custom headers in the form of name-value pairs
+| headers | object | Optional custom headers in the form of name-value pairs
 | attachments | Array | Optional <<attachments,attachments>> to include in the e-mail
 |===
 
@@ -156,7 +156,7 @@ Properties of each element in the array
 |===
 | Name | Kind | Details
 | fileName | string | Attachment file name
-| data | * | Attachment stream
+| data | ByteSource | Attachment stream
 | mimeType | string | Optional specification of attachment content type.  If not specified, it will be inferred from the filename.
 | headers | object | Optional attachment headers in the form of name-value pairs.
 |===


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-mail.adoc` with the current xp source (branch `fix/jsdoc-lib-mail`).

Fixes:

- **Signature fix:** `from` Kind `string` → `string | string[]` (TS type and JSDoc say it accepts an array).
- **Signature fix:** `replyTo` Kind `string` → `string | string[]` (TS type and JSDoc say it accepts an array).
- **Signature fix:** `headers` Kind `string` → `object` (it is `Record<string, string>`, not a string).
- **Signature fix:** attachment `data` Kind `*` → `ByteSource` (matches the `Attachment` interface in `mail.ts`).
- **Description fix:** Prose mentioning which params accept arrays now lists `from`, `to`, `cc`, `bcc` and `replyTo` (was only `to`, `cc`, `bcc`), matching the JSDoc on `send`.

Source xp ref: `fix/jsdoc-lib-mail` (post-audit).