### PR TITLE
Sync lib-portal doc with xp source #3

### DIFF
--- a/docs/libraries/lib-portal.adoc
+++ b/docs/libraries/lib-portal.adoc
@@ -105,6 +105,9 @@ Parameters
 ! label    ! string  ! <optional> ! source  ! Label of the attachment.
 ! download ! boolean ! <optional> ! false   ! Set to `true` if the disposition header should be set to attachment.
 ! type     ! string  ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
+! project  ! string  ! <optional> !         ! Name of the project.
+! branch   ! string  ! <optional> !         ! Name of the branch.
+! baseUrl  ! string  ! <optional> !         ! Custom baseUrl.
 ! params   ! object  ! <optional> !         ! Custom query parameters to append to the URL.
 !===
 
@@ -118,7 +121,6 @@ Returns
 [.lead]
 Example
 
-.Obtains list of active tasks:
 [source,typescript]
 ----
 import {attachmentUrl} from '/lib/xp/portal';
@@ -167,7 +169,6 @@ Returns
 [.lead]
 Example
 
-.Obtains list of active tasks:
 [source,typescript]
 ----
 import {componentUrl} from '/lib/xp/portal';
@@ -175,12 +176,6 @@ import {componentUrl} from '/lib/xp/portal';
 const url = componentUrl({
   component: 'main/0'
 });
-----
-
-.Return value:
-[source,typescript]
-----
-const expected = 'ComponentUrlParams{type=server, params={}, component=main/0}'
 ----
 
 === getComponent
@@ -286,7 +281,7 @@ Returns the key of ID provider in the current execution context.
 [.lead]
 Returns
 
-*object* : The current ID provider as JSON.
+*string|null* : The current ID provider key, or `null` if no ID provider is bound to the current context.
 
 [.lead]
 Example
@@ -311,7 +306,7 @@ const expected = "myidprovider";
 
 === getMultipartForm
 
-Returns a JSON containing multipart items. If not a multipart request, then this function returns `undefined`.
+Returns a JSON containing multipart items. If the request is not multipart, an empty object is returned.
 
 [.lead]
 Returns
@@ -359,7 +354,7 @@ const expected = {
 
 === getMultipartItem
 
-Returns a JSON containing a named multipart item. If the item does not exist, it returns `undefined`.
+Returns a JSON containing a named multipart item. If the item does not exist, it returns `null`.
 
 [.lead]
 Parameters
@@ -404,7 +399,7 @@ const expected = {
 
 === getMultipartStream
 
-Returns a data stream for a named multipart item.
+Returns a data stream for a named multipart item. If the item does not exist, it returns `null`.
 
 [.lead]
 Parameters
@@ -437,7 +432,7 @@ const stream2 = getMultipartStream('item2', 1);
 
 === getMultipartText
 
-Returns the multipart item data as text.
+Returns the multipart item data as text. If the item does not exist, it returns `null`.
 
 [.lead]
 Parameters
@@ -564,7 +559,6 @@ Parameters
 !===
 ! Name        ! Type   ! Attributes ! Default ! Description
 ! idProvider  ! string ! <optional> !         ! Key of an ID provider. If idProvider is not set, then the id provider corresponding to the current execution context will be used.
-! contextPath ! string ! <optional> ! vhost   ! Context path. Either vhost (using vhost target path) or relative to the current path.
 ! type        ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
 ! params      ! object ! <optional> !         ! Custom query parameters to append to the URL.
 !===
@@ -650,14 +644,17 @@ Parameters
 .Properties
 !===
 ! Name       ! Type   ! Attributes ! Default ! Description
-! id         ! string !            !         ! ID of the image content.
-! path       ! string !            !         ! Path to the image. If id is specified, this parameter is not used.
-! scale      ! string !            !         ! Required. Options are width(px), height(px), block(width, height) and square(px).
+! id         ! string ! <optional> !         ! ID of the image content. Either `id` or `path` is required.
+! path       ! string ! <optional> !         ! Path to the image. If `id` is specified, this parameter is not used.
+! scale      ! string !            !         ! Required. Options are `width(px)`, `height(px)`, `block(width,height)`, `square(px)`, `max(px)`, `wide(width,height)` and `full`.
 ! quality    ! number ! <optional> ! 85      ! Quality for JPEG images, ranges from 0 (max compression) to 100 (min compression).
 ! background ! string ! <optional> !         ! Background color.
 ! format     ! string ! <optional> !         ! Format of the image.
 ! filter     ! string ! <optional> !         ! A number of filters are available to alter the image appearance, for example, blur(3), grayscale(), rounded(5), etc.
 ! type       ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
+! project    ! string ! <optional> !         ! Name of the project.
+! branch     ! string ! <optional> !         ! Name of the branch.
+! baseUrl    ! string ! <optional> !         ! Custom baseUrl.
 ! params     ! object ! <optional> !         ! Custom query parameters to append to the URL.
 !===
 
@@ -706,7 +703,6 @@ Parameters
 ! Name        ! Type   ! Attributes ! Default ! Description
 ! idProvider  ! string ! <optional> !         ! Id provider key. If idProvider is not set, then the id provider corresponding to the current execution context will be used.
 ! redirect    ! string ! <optional> !         ! The URL to redirect to after the login.
-! contextPath ! string ! <optional> ! vhost   ! Context path. Either vhost (using vhost target path) or relative to the current path.
 ! type        ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
 ! params      ! object ! <optional> !         ! Custom query parameters to append to the URL.
 !===
@@ -740,7 +736,6 @@ Parameters
 !===
 ! Name        ! Type   ! Attributes ! Default ! Description
 ! redirect    ! string ! <optional> !         ! The URL to redirect to after the logout.
-! contextPath ! string ! <optional> ! vhost   ! Context path. Either vhost (using vhost target path) or relative to the current path.
 ! type        ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
 ! params      ! object ! <optional> !         ! Custom query parameters to append to the URL.
 !===
@@ -772,11 +767,13 @@ Parameters
 [caption=""]
 .Properties
 !===
-! Name   ! Type   ! Attributes ! Default ! Description
-! id     ! string ! <optional> !         ! Id of a content. If id is set, then path is not used.
-! path   ! string ! <optional> !         ! Path of a content. Relative paths are resolved based on the current context.
-! type   ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
-! params ! object ! <optional> !         ! Custom query parameters to append to the URL.
+! Name    ! Type   ! Attributes ! Default ! Description
+! id      ! string ! <optional> !         ! Id of a content. If id is set, then path is not used.
+! path    ! string ! <optional> !         ! Path of a content. Relative paths are resolved based on the current context.
+! type    ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute` or `websocket`.
+! project ! string ! <optional> !         ! Project of the context.
+! branch  ! string ! <optional> !         ! Branch of the project for context.
+! params  ! object ! <optional> !         ! Custom query parameters to append to the URL.
 !===
 
 |===
@@ -950,6 +947,56 @@ const url = apiUrl({
 });
 ----
 
+=== baseUrl
+
+Generates a base URL.
+
+[.lead]
+Parameters
+
+[%header,cols="1%,1%,98%a"]
+[frame="none"]
+[grid="none"]
+|===
+| Name   | Type   | Description
+| params | object | Input parameters as JSON
+
+[%header,cols="1%,1%,1%,1%,96%a"]
+[frame="topbot"]
+[grid="none"]
+[caption=""]
+.Properties
+!===
+! Name    ! Type   ! Attributes ! Default ! Description
+! type    ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute` or `websocket`.
+! id      ! string ! <optional> !         ! ID of the content.
+! path    ! string ! <optional> !         ! Path to the content.
+! project ! string ! <optional> !         ! Name of the project to use for resolving the URL.
+! branch  ! string ! <optional> !         ! Name of the branch to use for resolving the URL.
+!===
+
+|===
+
+[.lead]
+Returns
+
+*string* : The generated URL.
+
+[.lead]
+Example
+
+[source,typescript]
+----
+import {baseUrl} from '/lib/xp/portal';
+
+const url = baseUrl({
+  type: 'server',
+  path: '/path',
+  project: 'explicit-project',
+  branch: 'explicit-branch'
+});
+----
+
 === serviceUrl
 
 WARNING: HTTP services are deprecated in XP 8 in favor of <<../framework/universal-api#, Universal APIs>>. Use <<apiUrl>> for new code; `serviceUrl()` is retained for backward compatibility with legacy services in `src/main/resources/services/`.
@@ -1023,7 +1070,7 @@ Parameters
 .Properties
 !===
 ! Name   ! Type   ! Attributes ! Default ! Description
-! path   ! string !            !         ! Path of the resource.
+! path   ! string \| string[] !  !  ! Path to the resource. If a string is provided, it is treated as a full path. If an array of strings is provided, each element is treated as a path segment and will be joined using `/`.
 ! type   ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute` or `websocket`.
 ! params ! object ! <optional> !         ! Custom query parameters to append to the URL.
 !===


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-portal.adoc` with the current xp source
(`fix/jsdoc-lib-portal` branch — post-JSDoc-audit, internally consistent
with the Java handlers and TS declarations).

## Coverage

- **Added `baseUrl`** — function exists in `portal.ts` but was missing
  from the doc page.

## Signature fixes

- **`idProviderUrl`, `loginUrl`, `logoutUrl`** — removed `contextPath`
  parameter; the underlying handlers no longer expose it (no
  `setContextPath` on the Java side).
- **`attachmentUrl`** — added `project`, `branch`, `baseUrl` params.
- **`imageUrl`** — added `project`, `branch`, `baseUrl` params; marked
  `id` and `path` as `<optional>` (one of them is required); completed
  `scale` options list (added `max(px)`, `wide(width,height)`, `full`).
- **`pageUrl`** — added `project` and `branch` params; `type` now
  documents `websocket` as well.
- **`url`** — `path` accepts `string | string[]`, not just `string`;
  description explains array-as-path-segments behavior.

## Behavioral fixes

- **`getMultipartForm`** — corrected: returns an empty object when the
  request is not multipart (not `undefined`).
- **`getMultipartItem`** — corrected: returns `null` when not found
  (not `undefined`).
- **`getMultipartStream`, `getMultipartText`** — added that they return
  `null` if the item does not exist.
- **`getIdProviderKey`** — return type was `*object*` "current ID
  provider as JSON"; corrected to `*string|null*` (the function
  returns the key string).

## Example fixes

- **`componentUrl`** — removed a fictitious "Return value" block that
  showed a Java debug `toString()` form (`'ComponentUrlParams{...}'`)
  rather than an actual return value.
- **`attachmentUrl`, `componentUrl`** — removed stale copy-pasted
  captions ("Obtains list of active tasks").

Source xp ref: `fix/jsdoc-lib-portal` (post-JSDoc-audit).