### PR TITLE
lib-project doc fixes #3

### DIFF
--- a/docs/libraries/lib-project.adoc
+++ b/docs/libraries/lib-project.adoc
@@ -75,8 +75,7 @@ const currentPermissions = addPermissions({
 [source,typescript]
 ----
 const expected = {
-  id: 'my-project',
-  permissions: {
+    permissions: {
         owner: [
             'user:mystore:user1',
             'user:mystore:user2'
@@ -105,8 +104,8 @@ Parameters
 | Name | Type | Attributes | Description
 | id | string | | Unique project id (alphanumeric characters and hyphens allowed).
 | displayName | string | | Project display name.
-| parent | string | <optional> | image:xp-760.svg[XP 7.6.0,opts=inline] Parent project id. If provided, the new project will be a Content Layer that automatically inherits changes from the parent project.
-
+| parents | string[] | <optional> | Parent project ids. If provided, the new project will be a Content Layer that automatically inherits changes from its parent projects.
+| parent | string | <optional> | image:xp-760.svg[XP 7.6.0,opts=inline] Deprecated — use `parents` instead. Parent project id.
 | description | string | <optional> | Project description.
 | language | string | <optional> | Default project language.
 | siteConfig | Object.<string, Object>[] | <optional> | Applications (with optional configurations) to be assigned to the project
@@ -165,7 +164,7 @@ try {
 const expected = {
   id: 'my-project',
   displayName: 'My Content Project',
-  permissions: [],
+  permissions: {},
   readAccess: {
     public: true
   }
@@ -381,12 +380,16 @@ const projects = list();
 const expected = [{
     id: 'default',
     displayName: 'Default',
-    description: 'Default project'
+    description: 'Default project',
+    permissions: {},
+    readAccess: {
+        public: true
+    }
 },
 {
     id: 'my-project',
     displayName: 'My Content Project',
-    permissions: [],
+    permissions: {},
     readAccess: {
         public: true
     }
@@ -520,9 +523,9 @@ Example
 .Set content project as not available for public READ access
 [source,typescript]
 ----
-import {addPermissions} from '/lib/xp/project';
+import {modifyReadAccess} from '/lib/xp/project';
 
-const currentPermissions = addPermissions({
+const currentReadAccess = modifyReadAccess({
     id: 'my-project',
     readAccess: {
         public: false
@@ -534,7 +537,6 @@ const currentPermissions = addPermissions({
 [source,typescript]
 ----
 const expected = {
-    id: 'my-project',
     readAccess: {
         public: false
     }
@@ -596,7 +598,6 @@ const currentPermissions = removePermissions({
 [source,typescript]
 ----
 const expected = {
-    id: 'my-project',
     permissions: {
         owner: [
             'user:mystore:user1'
@@ -612,6 +613,8 @@ const expected = {
 image:xp-7110.svg[XP 7.11.0,opts=inline]
 
 Returns available applications of a specified project. The result contains active apps assigned to the project and all of its parents, if any.
+
+NOTE: User must be a member of one of the project roles, or either `system.admin` or `cms.admin` role.
 
 [.lead]
 Parameters

--- a/docs/libraries/lib-project.adoc
+++ b/docs/libraries/lib-project.adoc
@@ -105,7 +105,6 @@ Parameters
 | id | string | | Unique project id (alphanumeric characters and hyphens allowed).
 | displayName | string | | Project display name.
 | parents | string[] | <optional> | Parent project ids. If provided, the new project will be a Content Layer that automatically inherits changes from its parent projects.
-| parent | string | <optional> | image:xp-760.svg[XP 7.6.0,opts=inline] Deprecated — use `parents` instead. Parent project id.
 | description | string | <optional> | Project description.
 | language | string | <optional> | Default project language.
 | siteConfig | Object.<string, Object>[] | <optional> | Applications (with optional configurations) to be assigned to the project


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-project.adoc` with the current xp source on `fix/jsdoc-lib-project` (post-audit branch from enonic/xp#11991), verified against the Java handlers in `modules/lib/lib-project/src/main/java/...`.

## Fixes

- **Signature fix — `create`**: added the `parents: string[]` parameter (current canonical form). Re-labelled `parent` as deprecated, since the source JSDoc/TS now marks it as such (`Deprecated: use 'parents' param`).
- **Example fix — `addPermissions` sample response**: removed the spurious `id` field. `ProjectPermissionsMapper` only emits `{permissions: {...}}`; verified by `ModifyProjectPermissionsHandlerTest.js` (`assert.assertJsonEquals({permissions: {...}}, result)`).
- **Example fix — `removePermissions` sample response**: same — removed the spurious `id` field.
- **Example fix — `modifyReadAccess` example & sample**: the example called `addPermissions` with a `readAccess` arg (which `addPermissions` does not accept); replaced with `modifyReadAccess`. Sample response also had a stray `id` field — `ProjectReadAccessMapper` only emits `{readAccess: {public: <bool>}}`; verified by `ModifyProjectReadAccessHandlerTest.js`.
- **Example fix — `permissions: []` → `permissions: {}`** in the `create` and `list` sample responses. Empty permissions serialize as an empty object via `ProjectPermissionsMapper.serialize` (which calls `gen.map("permissions"); ...; gen.end()`), never as an array.
- **Behavioral fidelity — `getAvailableApplications`**: added the missing auth note ("User must be a member of one of the project roles, or either `system.admin` or `cms.admin` role"), matching the JSDoc.

Source xp ref: `fix/jsdoc-lib-project` (post-audit).