### PR TITLE
lib-sse doc fixes #3

### DIFF
--- a/docs/libraries/lib-sse.adoc
+++ b/docs/libraries/lib-sse.adoc
@@ -109,7 +109,7 @@ sendToGroup({group: 'live', message: {data: 'Update'}});
 
 === close
 
-Closes an SSE connection. The connection's `sseEvent` handler will receive a `close` event.
+Closes an SSE connection. The connection's `sseEvent` function will receive a `close` event.
 
 [.lead]
 Parameters
@@ -162,10 +162,14 @@ Example
 
 [source,typescript]
 ----
-import {isOpen} from '/lib/xp/sse';
+import {isOpen, send} from '/lib/xp/sse';
 
-if (!isOpen({clientId: clientId})) {
-    return;
+for (let i = 0; i < 10; i++) {
+    if (!isOpen({clientId: clientId})) {
+        break;
+    }
+    const data = computeExpensiveData(i);
+    send({clientId: clientId, message: {event: 'update', data: data}});
 }
 ----
 


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-sse.adoc` with the current xp source (branch `fix/jsdoc-lib-sse`).

Fixes:

- **Style fix** — `close` description: "sseEvent **handler**" → "sseEvent **function**". The project CLAUDE.md flags "handler" as HTTP-flavored and awkward for events; the same page already uses "function" in the `clientId` row a few sections up.
- **Example fix** — `isOpen` example: replaced trivial early-return with the canonical loop pattern (abort long-running work when client disconnects). Matches the source example at `xp/modules/lib/lib-sse/src/main/resources/lib/xp/examples/sse/isOpen.js` and aligns with the function's stated purpose ("Use it to abort expensive work… when the client has disconnected").

Coverage and signature fidelity were already correct: all 7 exported functions (`send`, `sendToGroup`, `close`, `isOpen`, `addToGroup`, `removeFromGroup`, `getGroupSize`) were documented with accurate parameter shapes and return types matching `sse.ts` and `SseManagerBean.java`.

Source xp ref: `fix/jsdoc-lib-sse` (post-audit branch).