### PR TITLE
Sync lib-task doc with xp source #3

### DIFF
--- a/docs/libraries/lib-task.adoc
+++ b/docs/libraries/lib-task.adoc
@@ -151,7 +151,7 @@ if (!isRunning('com.enonic.myapp:clean-up-task')) {
 [#list]
 === list
 
-Returns the list of running tasks with their current state and progress details.
+Returns the list of active tasks with their current state and progress details.
 On clustered environments aggregated list is returned.
 
 [.lead]
@@ -172,7 +172,7 @@ Parameters
 !===
 ! Name  ! Type   ! Attributes ! Description
 ! name  ! string ! <optional> ! Filter by name
-! state ! object ! <optional> ! Filter by task state (`WAITING` \| `RUNNING` \| `FINISHED` \| `FAILED`).
+! state ! string ! <optional> ! Filter by task state (`WAITING` \| `RUNNING` \| `FINISHED` \| `FAILED`).
 !===
 
 |===
@@ -340,8 +340,6 @@ const taskId = executeFunction({
 
 Causes the current execution thread to sleep (temporarily cease execution) for the specified number of milliseconds.
 
-IMPORTANT: This function will only work inside a task.
-
 [.lead]
 Parameters
 
@@ -409,7 +407,7 @@ Parameters
 [.lead]
 Returns
 
-*string* : Id of the task function that will be executed.
+*string* : Id of the task that will be executed.
 
 [.lead]
 Example
@@ -429,9 +427,9 @@ const taskId = executeFunction({
 
 === submitTask
 
-Submits a named task to be executed in the background and returns an id representing the task.
+Submits a task to be executed in the background and returns an id representing the task.
 
-NOTE: This function returns immediately. The callback function will be executed asynchronously.
+NOTE: This function returns immediately. The task will be executed asynchronously.
 
 TIP: lib-task prior version 7.6 does not submit distributable named tasks, instead task always gets executed locally.
 Recompile your application with the newer library version in order for tasks to be distributable.
@@ -454,7 +452,7 @@ Parameters
 !===
 ! Name   ! Type   ! Attributes ! Description
 ! descriptor   ! string !            ! Descriptor of the task to execute. Descriptor can be relative to the current application, or a fully qualified task descriptor name (<appname>:<taskname>) image:xp-7130.svg[XP 7.13.0,opts=inline]
-! name ! string ! <optional> ! Optional name of the task which appears in task info. If not specified, descriptor name will be used instead.
+! name ! string ! <optional> ! Optional name of the task which appears in task info. If not specified, the descriptor key will be used instead.
 ! config ! object ! <optional> ! Configuration parameters to pass to the task to be executed. The object must be valid according to the schema defined in the form of the task descriptor XML.
 !===
 
@@ -518,7 +516,7 @@ Properties
 | user        | string | Key of the user that submitted the task
 | startTime   | string | Time when the task was submitted (in ISO-8601 format)
 | progress    | object | Progress information provided by the running task
-| node        | string | XP cluster node the task is running on image:xp-7130.svg[XP 7.13.0,opts=inline]
+| node        | string | Identifier of the cluster node where the task is running. Absent when no cluster is configured. image:xp-7130.svg[XP 7.13.0,opts=inline]
 
 [%header,cols="1%,1%,98%a", options="header"]
 [grid="none"]


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-task.adoc` with the current xp source
(`fix/jsdoc-lib-task` branch, post-JSDoc audit, enonic/xp #11991).

## Fixes

- **Signature fix** — `list()`: `state` filter type was `object`; the
  source declares it as a string union (`'WAITING' | 'RUNNING' |
  'FINISHED' | 'FAILED'`).
- **Behavioral fix** — `list()` description: "list of running tasks"
  was misleading; the Java handler (`ListTasksHandler.list()` ->
  `taskService.getAllTasks()`) returns tasks in all states. The page's
  own example already showed `FINISHED` and `FAILED` rows. Now reads
  "list of active tasks", matching the source JSDoc.
- **Behavioral fix** — `sleep()`: dropped the incorrect note "This
  function will only work inside a task." `SleepHandler.java` has no
  task-context check and just calls `TimeUnit.MILLISECONDS.sleep`.
- **Behavioral fix** — `submitTask()` `name` property: said the
  fallback was the "descriptor name"; the source (post-audit) says
  "descriptor key", which is what `SubmitTaskParams` actually uses.
- **Style fix** — `submitTask()`: removed stale "callback function"
  wording (copied from `executeFunction`) and "named task" framing;
  matches the audit fix in xp.
- **Style fix** — `executeFunction()` returns: "Id of the task function
  that will be executed" -> "Id of the task that will be executed",
  consistent with the source and with `submitTask()`'s wording.
- **Behavioral fix** — `TaskInfo.node`: noted that the property is
  absent when no cluster is configured (TaskMapper emits `null` for
  the field and the script map generator skips null values). Source
  (post-audit) marks this `node?: string` and documents the same.

Coverage: all seven exported functions (`get`, `isRunning`, `list`,
`progress`, `sleep`, `executeFunction`, `submitTask`) were already
documented; no new sections needed.

Source xp ref: `fix/jsdoc-lib-task` (post-JSDoc audit). No xp-side
behavior changes.