### PR TITLE
lib-value doc fixes #3

### DIFF
--- a/docs/libraries/lib-value.adoc
+++ b/docs/libraries/lib-value.adoc
@@ -37,9 +37,9 @@ Parameters
 [frame="none"]
 [grid="none"]
 |===
-| Name   | Type   | Description
-| name   | string | The binary name
-| stream |        | The binary stream
+| Name   | Type       | Description
+| name   | string     | The binary name
+| stream | ByteSource | The binary stream
 |===
 
 [.lead]
@@ -70,7 +70,7 @@ Returns
 
 === geoPointString
 
-Creates a GeoPoint value as a string.
+Creates a GeoPoint value from a comma-separated latitude and longitude string.
 
 [.lead]
 Parameters
@@ -120,7 +120,7 @@ Parameters
 [grid="none"]
 |===
 | Name  | Type           | Description
-| value | string \| Date | A ISO local date-time string (e.g '2011-12-03') or a Date object
+| value | string \| Date | An ISO local date string (e.g '2011-12-03') or a Date object
 |===
 
 [.lead]
@@ -160,7 +160,7 @@ Parameters
 [grid="none"]
 |===
 | Name  | Type           | Description
-| value | string \| Date | A ISO local date-time string (e.g '10:15:30') or a Date object
+| value | string \| Date | An ISO local time string (e.g '10:15:30') or a Date object
 |===
 
 [.lead]


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-value.adoc` with the current xp source.

## Coverage

All 8 functions exported from `modules/lib/lib-value/src/main/resources/lib/xp/value.ts` (`binary`, `geoPoint`, `geoPointString`, `instant`, `localDate`, `localDateTime`, `localTime`, `reference`) were already present on the page — no missing functions.

## Fixes

- **Signature fix** — `binary`: `stream` parameter Type column was empty; filled in `ByteSource` (matches `ByteSource` from `@enonic-types/core` in the source `.ts`).
- **Behavioral fix** — `geoPointString`: description was "Creates a GeoPoint value **as** a string"; corrected to "Creates a GeoPoint value **from** a comma-separated latitude and longitude string". The function takes a string and returns a GeoPoint.
- **Signature fix** — `localDate`: parameter description said "A ISO local date-**time** string (e.g '2011-12-03')". The function parses an ISO local **date** (`LocalDate.parse`), so corrected to "An ISO local date string". Same typo class as the JSDoc fix in xp PR for #11991.
- **Signature fix** — `localTime`: parameter description said "A ISO local date-**time** string (e.g '10:15:30')". The function parses an ISO local **time** (`LocalTime.parse`), so corrected to "An ISO local time string".

No structural changes; targeted edits only.

Source xp ref: `fix/jsdoc-lib-value` (post-audit, commit `258ccef`).