### PR TITLE
Sync lib-vhost doc with xp source #3

### DIFF
--- a/docs/libraries/lib-vhost.adoc
+++ b/docs/libraries/lib-vhost.adoc
@@ -30,58 +30,55 @@ You are now ready to use the API.
 
 === isEnabled
 
-Returns value which is set for the `enabled` property in the `com.enonic.xp.web.vhost.cfg` file.
+Returns the value of the `enabled` property in the `com.enonic.xp.web.vhost.cfg` file.
 
 [.lead]
 Returns
 
-*Boolean* : Returns `true` if vhost mapping is enabled, otherwise `false`.
+*boolean* : `true` if vhost mapping is enabled, otherwise `false`.
 
 [.lead]
 Example
 
 [source,typescript]
 ----
-import vhostLib from '/lib/xp/vhost';
+import {isEnabled} from '/lib/xp/vhost';
 
-const isEnabled = vhostLib.isEnabled();
+const enabled = isEnabled();
 ----
 
 === list
 
-Returns list of vhost mappings which are specified in the `com.enonic.xp.web.vhost.cfg` file.
+Returns the virtual host mappings configured in `com.enonic.xp.web.vhost.cfg`.
 
 [.lead]
 Returns
 
-*Object* : Returns an object with  `vhosts` array.
-
+*object* : (<<virtualHosts,`VirtualHosts`>>) Object with a `vhosts` array. The array is empty when no mappings are configured.
 
 [.lead]
 Example
 
 [source,typescript]
 ----
-import vhostLib from '/lib/xp/vhost';
+import {list} from '/lib/xp/vhost';
 
-const vhostMappings = vhostLib.list();
-
-const vhosts = vhostMappings.vhosts;
+const {vhosts} = list();
 ----
 
-For instance, if the `com.enonic.xp.web.vhost.cfg` file contains the following mapping:
+For instance, given the following `com.enonic.xp.web.vhost.cfg`:
 
 [source,properties]
 ----
 mapping.admin.host = localhost
-mapping.admin.source = /admin
+mapping.admin.source = /
 mapping.admin.target = /admin
 mapping.admin.idProvider.system = default
 
-mapping.admintool.host = localhost
-mapping.admintool.source = /admin
-mapping.admintool.target = /admin
-mapping.admintool.idProvider.system = default
+mapping.api.host = api.localhost
+mapping.api.source = /
+mapping.api.target = /api
+mapping.api.idProvider.system = default
 ----
 
 .Sample response
@@ -90,29 +87,92 @@ mapping.admintool.idProvider.system = default
 const expected = {
   vhosts: [
     {
-      name: "admin",
-      source: "/admin",
-      target: "/admin",
-      host: "localhost",
-      defaultIdProviderKey: "system",
+      name: 'admin',
+      source: '/',
+      target: '/admin',
+      host: 'localhost',
+      defaultIdProviderKey: 'system',
       idProviderKeys: [
-        {
-          idProviderKey: "system"
-        }
+        {idProviderKey: 'system'}
       ]
     },
     {
-      name: "admintool",
-      source: "/admin",
-      target: "/admin",
-      host: "localhost",
-      defaultIdProviderKey: "system",
+      name: 'api',
+      source: '/',
+      target: '/api',
+      host: 'api.localhost',
+      defaultIdProviderKey: 'system',
       idProviderKeys: [
-        {
-          idProviderKey: "system"
-        }
+        {idProviderKey: 'system'}
       ]
     }
   ]
-}
+};
 ----
+
+== Type Definitions
+
+=== VirtualHosts
+[[virtualHosts]]
+
+[.lead]
+Type
+
+*object*
+
+[.lead]
+Properties
+
+[%header,cols="1%,1%,98%a"]
+[frame="none"]
+[grid="none"]
+|===
+| Name   | Type                              | Description
+| vhosts | <<virtualHost,`VirtualHost[]`>>   | All configured virtual host mappings. Empty when none are configured.
+
+|===
+
+=== VirtualHost
+[[virtualHost]]
+
+[.lead]
+Type
+
+*object*
+
+[.lead]
+Properties
+
+[%header,cols="1%,1%,98%a"]
+[frame="none"]
+[grid="none"]
+|===
+| Name                 | Type                                  | Description
+| name                 | string                                | Mapping name (the suffix used in `mapping.<name>.*` config keys).
+| source               | string                                | Source path that the mapping matches.
+| target               | string                                | Target path that the mapping rewrites to.
+| host                 | string                                | Host name that the mapping matches.
+| defaultIdProviderKey | string                                | Optional. Key of the default ID provider, when configured.
+| idProviderKeys       | <<idProviderKey,`IdProviderKey[]`>>   | Optional. ID providers attached to the mapping.
+
+|===
+
+=== IdProviderKey
+[[idProviderKey]]
+
+[.lead]
+Type
+
+*object*
+
+[.lead]
+Properties
+
+[%header,cols="1%,1%,98%a"]
+[frame="none"]
+[grid="none"]
+|===
+| Name          | Type   | Description
+| idProviderKey | string | ID provider key.
+
+|===


### PR DESCRIPTION
Part of #3.

Synced `docs/libraries/lib-vhost.adoc` with the current xp source
(`modules/lib/lib-vhost`, master HEAD — no JSDoc-audit branch exists
for `lib-vhost`).

Findings:

- COVERAGE — clean. Both exported functions (`isEnabled`, `list`)
  were already documented.
- SIGNATURE FIDELITY — return types written with capitalised
  `*Boolean*` / `*Object*`; the response shape (`VirtualHosts`,
  `VirtualHost`, `IdProviderKey`) was only implied through an
  inline example.
- BEHAVIORAL FIDELITY — `list()` description said "list of vhost
  mappings" but the function returns an object with a `vhosts`
  array.
- EXAMPLE FIDELITY — the sample `cfg` block defined two mappings
  with identical `host` + `source` (`localhost` + `/admin`), which
  would shadow each other and never match independently in
  practice.
- STYLE — examples used default-import style; siblings such as
  `lib-app` and `lib-cluster` use named imports inside example
  blocks.

Fixes:

- **signature fix** — lower-cased `*boolean*` / `*object*` return
  types; linked `list()` return to a `VirtualHosts` type reference.
- **added type definitions** — new `Type Definitions` section
  documents `VirtualHosts`, `VirtualHost` (including the optional
  `defaultIdProviderKey` and `idProviderKeys`) and `IdProviderKey`,
  matching the structural pattern used by `lib-app` and other
  reference pages.
- **example fix** — replaced the duplicate `admin` / `admintool`
  config sample with a realistic two-vhost config (`admin` on
  `localhost` and `api` on `api.localhost`); aligned the sample
  response to match. Switched the TS examples to named imports
  to match neighbouring lib pages.
- **behavior fix** — rephrased the `list()` description to
  accurately describe the returned object instead of "list".

Source xp ref: `master` (no `fix/jsdoc-lib-vhost` audit branch
exists).