### PR TITLE
Fix lib-event table syntax #3

### DIFF
--- a/docs/libraries/lib-event.adoc
+++ b/docs/libraries/lib-event.adoc
@@ -57,14 +57,14 @@ An object with the following keys and their values:
 [frame="topbot"]
 [grid="none"]
 [caption=""]
-!===
-! Name ! Type ! Description
-! type ! string ! Event type, for example `node.pushed` or `custom.myEvent`.
-! timestamp ! number ! Time the event was published, in milliseconds since the epoch.
-! localOrigin ! boolean ! `true` if the event was published on the current node, `false` if it was received from another cluster node.
-! distributed ! boolean ! `true` if the event was distributed across the cluster.
-! data ! object ! Event payload. Shape depends on the event `type`; for built-in node events, see <<lib-node#events, Node library>>.
-!===
+|===
+| Name | Type | Description
+| type | string | Event type, for example `node.pushed` or `custom.myEvent`.
+| timestamp | number | Time the event was published, in milliseconds since the epoch.
+| localOrigin | boolean | `true` if the event was published on the current node, `false` if it was received from another cluster node.
+| distributed | boolean | `true` if the event was distributed across the cluster.
+| data | object | Event payload. Shape depends on the event `type`; for built-in node events, see <<lib-node#events, Node library>>.
+|===
 
 [.lead]
 Returns


### PR DESCRIPTION
Hot-fix for the asciidoctor build error on master:

```
asciidoctor: ERROR: lib-event.adoc: line 61: table missing leading separator; recovering automatically
asciidoctor: ERROR: lib-event.adoc: line 66: dropping cells from incomplete row detected end of table
```

The "Event object passed to the callback" table at line 60 was using `!===` / `! ` separators, which are AsciiDoc's *nested-table* syntax (only valid inside an outer cell). For a top-level table, the separators must be `|===` / `| `. Introduced by #10 (sync-doc-lib-event).

Build run that failed: https://github.com/enonic/doc-code/actions/runs/25291119307

Part of #3.

The build also has duplicate-ID warnings in lib-app, lib-auth, lib-content, lib-context, lib-mail, lib-schema, lib-task — those are warnings, not errors, and don't fail the build at the current failure-level setting. Cleanup follow-up to come.