### PR TITLE
Drop redundant section ID anchors #3

### DIFF
--- a/docs/libraries/lib-app.adoc
+++ b/docs/libraries/lib-app.adoc
@@ -341,7 +341,6 @@ const result = getApplicationMode({
 == Type Definitions
 
 === Application
-[[application]]
 
 [.lead]
 Type
@@ -396,7 +395,6 @@ Properties
 |===
 
 === Icon
-[[icon]]
 
 [.lead]
 Type

--- a/docs/libraries/lib-auth.adoc
+++ b/docs/libraries/lib-auth.adoc
@@ -1128,7 +1128,6 @@ removeMembers('role:roleId', ['user:system:user1', 'group:system:group-a']);
 == Type Definitions
 
 === User
-[[user]]
 
 [.lead]
 Type

--- a/docs/libraries/lib-content.adoc
+++ b/docs/libraries/lib-content.adoc
@@ -1681,7 +1681,6 @@ const result = patch({
 ----
 
 === move
-[[move]]
 
 Renames a content or moves it to a new path
 

--- a/docs/libraries/lib-context.adoc
+++ b/docs/libraries/lib-context.adoc
@@ -137,7 +137,6 @@ const result = run({
 == Type Definitions
 
 === GetContext
-[[getcontext]]
 
 The shape of the object returned by `get()`.
 
@@ -172,7 +171,6 @@ The shape of the object returned by `get()`.
 <6> *attributes* (_object_) Custom attributes set on the context. Always present; may be empty. Only values of type `number`, `string`, `boolean`, or plain `object` are serialized.
 
 === RunContext
-[[runcontext]]
 
 The parameter object passed to `run()`. Any field omitted is inherited from the calling context.
 

--- a/docs/libraries/lib-mail.adoc
+++ b/docs/libraries/lib-mail.adoc
@@ -143,7 +143,6 @@ const defaultFromEmail = getDefaultFromEmail();
 == Objects
 
 === attachments
-[[attachments]]
 
 Array of attachments to include in an e-mail
 

--- a/docs/libraries/lib-schema.adoc
+++ b/docs/libraries/lib-schema.adoc
@@ -1405,7 +1405,6 @@ const expected = {
 == Type Definitions
 
 === Schema
-[[schema]]
 (abstract for <<content_type,ContentType>>, <<form_fragment,FormFragment>> and <<mixin,Mixin>>)
 
 [.lead]
@@ -1471,7 +1470,6 @@ Type
 *object*
 
 === Mixin
-[[mixin]]
 (extends <<schema,`Schema`>>)
 
 In XP 8 this is what was called `XData` in XP 7. Each mixin attaches optional metadata to a content item.
@@ -1494,7 +1492,6 @@ Properties
 |===
 
 === Component
-[[component]]
 (abstract for <<page,Page>>, <<part,Part>> and <<layout,Layout>>)
 
 [.lead]
@@ -1525,7 +1522,6 @@ Properties
 |===
 
 === Page
-[[page]]
 (extends <<component,`Component`>>)
 
 [.lead]
@@ -1546,7 +1542,6 @@ Properties
 |===
 
 === Layout
-[[layout]]
 (extends <<component,`Component`>>)
 
 [.lead]
@@ -1567,7 +1562,6 @@ Properties
 |===
 
 === Part
-[[part]]
 (extends <<component,`Component`>>)
 
 [.lead]
@@ -1588,7 +1582,6 @@ Properties
 |===
 
 === Site
-[[site]]
 
 [.lead]
 Type
@@ -1612,7 +1605,6 @@ Properties
 |===
 
 === Styles
-[[styles]]
 
 [.lead]
 Type
@@ -1678,7 +1670,6 @@ Properties
 |===
 
 === Icon
-[[icon]]
 
 [.lead]
 Type

--- a/docs/libraries/lib-task.adoc
+++ b/docs/libraries/lib-task.adoc
@@ -493,7 +493,6 @@ const taskId = submitTask({
 == Type Definitions
 
 === TaskInfo
-[[taskinfo]]
 
 [.lead]
 Type


### PR DESCRIPTION
Cleanup of the duplicate-ID warnings in the asciidoctor build.

Each removed line was an explicit `[[id]]` placed immediately after a `=== Heading` whose auto-generated ID was already the same value — creating a duplicate-ID warning on every build:

```
asciidoctor: WARNING: lib-schema.adoc: line 1409: id assigned to block already in use: schema
asciidoctor: WARNING: lib-app.adoc:    line 347:  id assigned to block already in use: application
... (16 warnings total)
```

17 redundant anchors deleted across 7 files. The auto-generated IDs from the `=== Heading` lines remain — cross-references like `<<schema, ...>>` continue to work unchanged.

The intentional alias `[[element]]` after `=== StyleElement` (a shorter alternative anchor) was left in place — it does not duplicate the auto-ID.

Companion to #26 (lib-event table fix). Together those two PRs clear the build.

Part of #3.