### PR TITLE
Drop XP 7.x version qualifiers from reference pages

### DIFF
--- a/docs/framework.adoc
+++ b/docs/framework.adoc
@@ -15,9 +15,9 @@ Enonic offers a powerful Server-side JavaScript/TypeScript development framework
 Here are some highlights:
 
 * *Integrated* with the Enonic applications runtime. Ship and execute server-side TypeScript/JavaScript.
-* *Compatible* across all releases of XP within a major version i.e. 7.x.x
+* *Compatible* across all releases of XP within a major version i.e. 8.x.x
 * *Supports* HTTP request-response, clustered events and background task execution
 * *Multithreaded* for ease of development and effective use of multi-core CPU architectures
 * *Fast and performant* as JavaScripts are compiled and adapted to the underlying architecture.
 * *Based on the https://wiki.commonjs.org/wiki/Modules/1.1[CommonJS module specification]*
-* *Powered by the GraalVM* Unlike most JavaScript frameworks, this is not powered by Node.js, but uses the Nashorn scripting engine. Next major release of XP is expected to be using GraalJS.
+* *Powered by the GraalVM* Unlike most JavaScript frameworks, this is not powered by Node.js, but uses the Nashorn scripting engine.

--- a/docs/framework/http.adoc
+++ b/docs/framework/http.adoc
@@ -75,7 +75,7 @@ The ``request`` object is passed to every HTTP function. It carries the request 
 <13> Parsed HTTP request cookies.
 <14> image:xp-8000.svg[XP 8.0.0,opts=inline] Locale strings in decreasing order of preference, derived from the `Accept-Language` header. When the client sends no `Accept-Language` header, the array contains a single element with the server's default locale.
 
-image:xp-7120.svg[XP 7.12.0,opts=inline] Use ``request.getHeader(name)`` to read a header case-insensitively. Prefer it over direct access to the ``headers`` object.
+Use ``request.getHeader(name)`` to read a header case-insensitively. Prefer it over direct access to the ``headers`` object.
 
 NOTE: Modifications to the ``headers`` object do not affect the result of ``getHeader(name)``.
 
@@ -104,7 +104,7 @@ The HTTP function returns a ``response`` object that XP converts to the outgoing
 <1> HTTP status code (default `200`).
 <2> Response body — a string or a JavaScript object.
 <3> MIME type (default `text/plain; charset=utf-8`).
-<4> Response headers. image:xp-7150.svg[XP 7.15.0,opts=inline] A value of `null` or `undefined` removes a header set by an upstream function or filter.
+<4> Response headers. A value of `null` or `undefined` removes a header set by an upstream function or filter.
 <5> Cookies to set on the response. See <<#cookies, Cookies>>.
 <6> URI to redirect to. If set, XP places it in the `Location` header and sets the status to `303`.
 <7> Site engine only. If `true`, the rendered page is post-processed for component tags (default `true`).

--- a/docs/framework/sites/mappings.adoc
+++ b/docs/framework/sites/mappings.adoc
@@ -86,8 +86,6 @@ Examples:
 * Regex with query string: `+pattern: '/endpoint\?bar=\d+&foo=.*'+`
 * Inverted via `invertPattern: true` together with `+pattern: '/section/.*'+`
 
-NOTE: Before image:xp-780.svg[XP 7.8.0,opts=inline] it was not possible to map an HTTP function or filter to the site itself.
-
 == Match mappings
 
 Match-based mappings can be used to automatically render content types without using page templates or associating content with an implementation directly. A common case is automatic handling of the content type `portal:fragment`.

--- a/docs/framework/websocket.adoc
+++ b/docs/framework/websocket.adoc
@@ -59,7 +59,7 @@ Event object example:
 <2> WebSocket session id.
 <3> Path of the request when WebSocket was opened.
 <4> Name/value pairs of the query/form parameters from the request when WebSocket was opened.
-<5> Authenticated user data when WebSocket was opened, if available. image:xp-760.svg[XP 7.6.0,opts=inline]
+<5> Authenticated user data when WebSocket was opened, if available.
 <6> Data returned from the WebSocket `GET` function.
 <7> Error message, if available.
 <8> WebSocket Close reason code, if available.

--- a/docs/libraries/lib-app.adoc
+++ b/docs/libraries/lib-app.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :imagesdir: ../images
 
-image:xp-7110.svg[XP 7.11.0,opts=inline] API for fetching and manipulating applications.
+API for fetching and manipulating applications.
 
 
 == Usage

--- a/docs/libraries/lib-auditlog.adoc
+++ b/docs/libraries/lib-auditlog.adoc
@@ -3,8 +3,6 @@
 :toc: right
 :imagesdir: ../images
 
-image:xp-720.svg[XP 7.2.0,opts=inline]
-
 This API provides functions for audit log management.
 
 == Usage

--- a/docs/libraries/lib-auth.adoc
+++ b/docs/libraries/lib-auth.adoc
@@ -810,7 +810,7 @@ An object with the following keys and their values:
 | idProvider | string | <optional> | Name of id provider where the user is stored. If not specified system id provider will be used.
 | skipAuth | boolean | <optional> | Skip authentication.  Default is `false` if not specified.
 | sessionTimeout | number | <optional> | Session timeout (in seconds). By default, the value of session.timeout from `com.enonic.xp.web.jetty.cfg`
-| scope image:xp-730.svg[XP 7.3.0,opts=inline] | string | <optional> | Defines the scope of the login. Valid values are `SESSION`, `REQUEST` and `NONE` (starting from version image:xp-780.svg[XP 7.8.0,opts=inline]). When scope is set to `SESSION` the login is persistent. If scope is set to `REQUEST` the login is only valid for the current request. Scope `NONE` allows to check correctness of username and password without logging into the system. Default is `SESSION` if not specified.
+| scope | string | <optional> | Defines the scope of the login. Valid values are `SESSION`, `REQUEST` and `NONE`. When scope is set to `SESSION` the login is persistent. If scope is set to `REQUEST` the login is only valid for the current request. Scope `NONE` allows to check correctness of username and password without logging into the system. Default is `SESSION` if not specified.
 |===
 
 [.lead]
@@ -1149,5 +1149,5 @@ Properties
 | email        | string  | The email of the user
 | login        | string  | The login name of the user
 | idProvider   | string  | The id provider where the user is stored
-| hasPassword  | boolean | image:xp-7150.svg[XP 7.15.0,opts=inline] Whether the user has a password set
+| hasPassword  | boolean | Whether the user has a password set
 |===

--- a/docs/libraries/lib-content.adoc
+++ b/docs/libraries/lib-content.adoc
@@ -94,7 +94,6 @@ addAttachment({
 ----
 
 === archive
-image:xp-780.svg[XP 7.8.0,opts=inline]
 
 Archives a content
 
@@ -475,7 +474,7 @@ if (result) {
 
 === duplicate
 
-image:xp-7120.svg[XP 7.12.0,opts=inline] Duplicates a content.
+Duplicates a content.
 
 [.lead]
 *Parameters:*
@@ -605,7 +604,7 @@ An object with the following keys and their values:
 |===
 | Name | Type | Attributes| Description
 | key | string | | Path or id to the parent content
-| versionId image:xp-720.svg[XP 7.2.0,opts=inline] | string | <optional> | Content version id
+| versionId | string | <optional> | Content version id
 |===
 
 [.lead]
@@ -886,8 +885,6 @@ const expected = {
 
 
 === getOutboundDependencies
-
-image:xp-720.svg[XP 7.2.0,opts=inline]
 
 Returns the list of content items that are outbound dependencies of specified content.
 
@@ -1886,7 +1883,7 @@ Returns
 
 *object* : Result of query
 
-image:xp-750.svg[XP 7.5.0,opts=inline] If `sort` was specified, results will contain system meta properties `_sort` and `_score: null`, otherwise `_score`
+If `sort` was specified, results will contain system meta properties `_sort` and `_score: null`, otherwise `_score`
  will have a relevant value.
 
 [.lead]
@@ -2164,7 +2161,6 @@ removeAttachment({key: '3381d720-993e-4576-b089-aaf67280a74c', name: ['document'
 ----
 
 === resetInheritance
-image:xp-760.svg[XP 7.6.0,opts=inline]
 
 Resets custom inheritance flags of a content item. For an item that was inherited from a parent content project/layer this action
 will reset specified changes made inside a specified layer.
@@ -2207,7 +2203,6 @@ resetInheritance({key: '/mySite/mycontent', projectName: 'layer-no', inherit: ['
 ----
 
 === restore
-image:xp-780.svg[XP 7.8.0,opts=inline]
 
 Restores a content from the archive
 

--- a/docs/libraries/lib-export.adoc
+++ b/docs/libraries/lib-export.adoc
@@ -3,8 +3,6 @@
 :toc: right
 :imagesdir: ../images
 
-image:xp-780.svg[XP 7.8.0,opts=inline]
-
 This API provides functions for creating and importing node-exports.
 
 == Usage

--- a/docs/libraries/lib-grid.adoc
+++ b/docs/libraries/lib-grid.adoc
@@ -3,7 +3,7 @@
 :toc: right
 :imagesdir: ../images
 
-image:xp-7100.svg[XP 7.10.0,opts=inline] This API provides functions that enable sharing data across all applications and cluster nodes.
+This API provides functions that enable sharing data across all applications and cluster nodes.
 
 NOTE: Due to distributed nature of `SharedMap` not all value types can be used. Strings, numbers, booleans, and pure JSON objects are supported. There is no runtime check for type compatibility due to performance reasons. Developers are themselves responsible for NOT modifying shared objects (keys and values) in place.
 

--- a/docs/libraries/lib-mail.adoc
+++ b/docs/libraries/lib-mail.adoc
@@ -126,7 +126,7 @@ const flag2 = send({
 === getDefaultFromEmail
 [[getDefaultFromEmail]]
 
-image:xp-7141.svg[XP 7.14.1,opts=inline] Returns the default _from_ email address configured in the <<../deployment/config#mail, XP mail configuration>>.
+Returns the default _from_ email address configured in the <<../deployment/config#mail, XP mail configuration>>.
 
 [.lead]
 Example

--- a/docs/libraries/lib-node.adoc
+++ b/docs/libraries/lib-node.adoc
@@ -564,7 +564,7 @@ const result = repo.diff({
 
 === duplicate
 
-image:xp-7120.svg[XP 7.12.0,opts=inline] Duplicates a node.
+Duplicates a node.
 
 [.lead]
 Parameters
@@ -925,7 +925,6 @@ const binaryStream = repo.getBinary({
 ----
 
 === getCommit
-image:xp-770.svg[XP 7.7.0,opts=inline]
 
 Returns a node version commit.
 

--- a/docs/libraries/lib-portal.adoc
+++ b/docs/libraries/lib-portal.adoc
@@ -28,7 +28,7 @@ You are now ready to use the API.
 
 === assetUrl
 ====
-Starting from image:xp-7150.svg[XP 7.15.0,opts=inline] `assetUrl` is deprecated and will be removed in future versions.
+`assetUrl` is deprecated and will be removed in future versions.
 https://developer.enonic.com/docs/lib-asset[`lib-asset`] and https://developer.enonic.com/docs/lib-static[`lib-static`] are introduced as a replacement.
 ====
 Generates URL to a static file.
@@ -827,8 +827,8 @@ Parameters
 ! Name  ! Type   ! Attributes ! Default ! Description
 ! value ! string !            !         ! Html value string to process.
 ! type  ! string ! <optional> ! server  ! URL type. Either `server` (server-relative URL) or `absolute`.
-! image:xp-770.svg[XP 7.7.0,opts=inline] imageWidths  ! number[] ! <optional> ! ! A comma-separated list of image widths. If this parameter is provided, all `<img>` tags will have an additional `srcset` attribute with image URLs generated for specified widths.
-! image:xp-780.svg[XP 7.8.0,opts=inline] imageSizes  ! string ! <optional> !! Specifies the width for an image depending on browser dimensions. The value has the following format: `(media-condition) width`. Multiple sizes are comma-separated.
+! imageWidths  ! number[] ! <optional> ! ! A comma-separated list of image widths. If this parameter is provided, all `<img>` tags will have an additional `srcset` attribute with image URLs generated for specified widths.
+! imageSizes  ! string ! <optional> !! Specifies the width for an image depending on browser dimensions. The value has the following format: `(media-condition) width`. Multiple sizes are comma-separated.
 !===
 
 |===

--- a/docs/libraries/lib-project.adoc
+++ b/docs/libraries/lib-project.adoc
@@ -2,8 +2,6 @@
 :toc: right
 :imagesdir: ../images
 
-image:xp-730.svg[XP 7.3.0,opts=inline]
-
 This API provides functions for management of Content Projects.
 
 == Usage
@@ -609,7 +607,6 @@ const expected = {
 ----
 
 === getAvailableApplications
-image:xp-7110.svg[XP 7.11.0,opts=inline]
 
 Returns available applications of a specified project. The result contains active apps assigned to the project and all of its parents, if any.
 

--- a/docs/libraries/lib-scheduler.adoc
+++ b/docs/libraries/lib-scheduler.adoc
@@ -2,8 +2,6 @@
 :toc: right
 :imagesdir: ../images
 
-image:xp-770.svg[XP 7.7.0,opts=inline]
-
 Functions for creating and managing scheduled jobs.
 
 == Usage

--- a/docs/libraries/lib-schema.adoc
+++ b/docs/libraries/lib-schema.adoc
@@ -1462,8 +1462,6 @@ Properties
 [[form_fragment]]
 (extends <<schema,`Schema`>>)
 
-In XP 8 this is what was called `Mixin` in XP 7.
-
 [.lead]
 Type
 
@@ -1472,7 +1470,7 @@ Type
 === Mixin
 (extends <<schema,`Schema`>>)
 
-In XP 8 this is what was called `XData` in XP 7. Each mixin attaches optional metadata to a content item.
+Each mixin attaches optional metadata to a content item.
 
 [.lead]
 Type
@@ -1642,7 +1640,7 @@ Properties
 [grid="none"]
 |===
 | Name                   | Type    | Description
-| name                   | string  | Mixin name (XP 8 mixin — what was called x-data in XP 7)
+| name                   | string  | Mixin name
 | optional               | boolean | `true` if optional
 | allowContentTypes      | string  | Allowed content type pattern
 

--- a/docs/libraries/lib-task.adoc
+++ b/docs/libraries/lib-task.adoc
@@ -451,7 +451,7 @@ Parameters
 .Properties
 !===
 ! Name   ! Type   ! Attributes ! Description
-! descriptor   ! string !            ! Descriptor of the task to execute. Descriptor can be relative to the current application, or a fully qualified task descriptor name (<appname>:<taskname>) image:xp-7130.svg[XP 7.13.0,opts=inline]
+! descriptor   ! string !            ! Descriptor of the task to execute. Descriptor can be relative to the current application, or a fully qualified task descriptor name (<appname>:<taskname>)
 ! name ! string ! <optional> ! Optional name of the task which appears in task info. If not specified, the descriptor key will be used instead.
 ! config ! object ! <optional> ! Configuration parameters to pass to the task to be executed. The object must be valid according to the schema defined in the form of the task descriptor XML.
 !===
@@ -515,7 +515,7 @@ Properties
 | user        | string | Key of the user that submitted the task
 | startTime   | string | Time when the task was submitted (in ISO-8601 format)
 | progress    | object | Progress information provided by the running task
-| node        | string | Identifier of the cluster node where the task is running. Absent when no cluster is configured. image:xp-7130.svg[XP 7.13.0,opts=inline]
+| node        | string | Identifier of the cluster node where the task is running. Absent when no cluster is configured.
 
 [%header,cols="1%,1%,98%a", options="header"]
 [grid="none"]

--- a/docs/libraries/lib-vhost.adoc
+++ b/docs/libraries/lib-vhost.adoc
@@ -2,8 +2,6 @@
 :toc: right
 :imagesdir: ../images
 
-image:xp-760.svg[XP 7.6.0,opts=inline]
-
 This API provides functions for retrieving information about existing virtual host mappings.
 
 == Usage

--- a/docs/libraries/lib-websocket.adoc
+++ b/docs/libraries/lib-websocket.adoc
@@ -152,7 +152,7 @@ sendToGroup('people', 'Notice this message!');
 
 === getGroupSize
 
-image:xp-760.svg[XP 7.6.0,opts=inline] Gets number of all sockets in a group.
+Gets number of all sockets in a group.
 
 NOTE: Calculating size of a group has a linear cost from total number of sockets.
 Consider using this method only if building a message is a resource consuming operation, otherwise it is better to simply `sendToGroup`.


### PR DESCRIPTION
Removes "starting from XP 7.x" / "available since 7.x" / "introduced in XP 7" type qualifiers and the `image:xp-7XX.svg` inline version badges from reference pages so they read as if XP 8 is the only version. The migration narrative stays in `docs/upgrade.adoc`; release-history stays in `docs/release.adoc`.

## Files touched (19)

- `docs/framework.adoc` — drops "i.e. 7.x.x" / "Next major release of XP is expected to be using GraalJS"
- `docs/framework/http.adoc` — drops two `xp-71XX.svg` badges
- `docs/framework/sites/mappings.adoc` — drops "Before XP 7.8.0 it was not possible to map …" NOTE
- `docs/framework/websocket.adoc` — drops one `xp-760.svg` badge
- `docs/libraries/lib-app.adoc`, `lib-auditlog.adoc`, `lib-auth.adoc`, `lib-content.adoc` (6×), `lib-export.adoc`, `lib-grid.adoc`, `lib-mail.adoc`, `lib-node.adoc` (2×), `lib-portal.adoc` (3×), `lib-project.adoc` (2×), `lib-scheduler.adoc`, `lib-schema.adoc` (3×), `lib-task.adoc` (2×), `lib-vhost.adoc`, `lib-websocket.adoc` — drop `xp-7XX.svg` "available since" badges; drop XP 7→XP 8 renaming comparisons in `lib-schema.adoc`

## Sample rewrites

- BEFORE: `Starting from image:xp-7150.svg[XP 7.15.0,opts=inline] \`assetUrl\` is deprecated…`
  AFTER: `\`assetUrl\` is deprecated…`
- BEFORE: `image:xp-7120.svg[XP 7.12.0,opts=inline] Duplicates a content.`
  AFTER: `Duplicates a content.`
- BEFORE: `In XP 8 this is what was called \`Mixin\` in XP 7.` (then a section header)
  AFTER: line removed; section header kept
- BEFORE: `NOTE: Before image:xp-780.svg[XP 7.8.0,opts=inline] it was not possible to map an HTTP function or filter to the site itself.`
  AFTER: removed
- BEFORE: `* *Compatible* across all releases of XP within a major version i.e. 7.x.x`
  AFTER: `* *Compatible* across all releases of XP within a major version i.e. 8.x.x`

## Intentionally KEPT

- `docs/tooling/build.adoc:7` — `NOTE: Upgrading from XP 7? See <<../upgrade#, the Upgrading guide>>.` This is a neutral cross-link to the migration guide, not an excuse for current behavior.

## Local validation

`asciidoctor --backend html5 --trace --failure-level ERROR --verbose -a icons=font -a setanchors=true -a sectlinks=true -a encoding=utf-8 -a linkattrs=true -a idprefix= -a toc=right -a outfilesuffix=.ahtml '**/*.adoc'` exits 0. Compared to a pre-change baseline, the only remaining warning is the pre-existing missing `xp-8000.svg` referenced by `framework/http.adoc` — present on master, not introduced here. All `xp-7XX.svg` "missing image" warnings disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)