### PR TITLE
Mark management mount as experimental

### DIFF
--- a/docs/framework/universal-api.adoc
+++ b/docs/framework/universal-api.adoc
@@ -153,6 +153,8 @@ To opt in, an API must include `"web"` in its `mount` list (see <<#descriptor,AP
 [#management-endpoint]
 == Management Endpoint
 
+WARNING: The `mount: "management"` feature is experimental and subject to change. The API shape, behavior, and configuration may change in future releases without the usual deprecation cycle. Avoid relying on it for production workloads.
+
 NOTE: The Management endpoint is for *advanced use only*. It is intended for extending XP's management capabilities (cluster operations, internal tooling, infrastructure integrations) — not for regular application APIs.
 
 An API can also be exposed on the *Management* endpoint by adding `"management"` to its `mount` list. The Management endpoint is a separate listener on its own port, distinct from the Portal endpoint — use it for internal or operational APIs that should not be reachable from the public network.


### PR DESCRIPTION
## Summary

Adds a WARNING admonition to the Management Endpoint section of `docs/framework/universal-api.adoc` clarifying that the `mount: "management"` feature is experimental. The existing NOTE about advanced-use-only audience is unchanged.

The pre-existing NOTE covers audience (advanced use only). The new WARNING covers stability — readers need to know the API shape and behavior may change without the usual deprecation cycle.

## Test plan

- [x] Diff inspected — admonition placed directly after the section heading, above the existing NOTE
- [x] AsciiDoc syntax matches the doc's other admonitions (`WARNING:` block style)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)