### PR TITLE
Fix broken image in tasks.adoc

### DIFF
--- a/docs/framework/tasks.adoc
+++ b/docs/framework/tasks.adoc
@@ -1,6 +1,6 @@
 = Tasks
 :toc: right
-:imagesdir: ../images
+:imagesdir: media
 
 The XP framework also supports execution of asynchronous (potentially long running) background tasks.
 


### PR DESCRIPTION
Corrects `:imagesdir:` from `../images` (non-existent) to `media`, matching the sibling `pipeline.adoc` convention. The `task-engine.svg` already lives at `docs/framework/media/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)