### PR TITLE
Note cms.cm.app deprecation in XP 8 upgrade

### DIFF
--- a/docs/libraries/lib-auth.adoc
+++ b/docs/libraries/lib-auth.adoc
@@ -685,8 +685,8 @@ const result = getMemberships('user:system:user1', true);
     },
     {
         type: "role",
-        key: "role:cms.cm.app",
-        displayName: "Content Manager App"
+        key: "role:cms.project.default.editor",
+        displayName: "Default project editor"
     }
 ]
 ----

--- a/docs/upgrade.adoc
+++ b/docs/upgrade.adoc
@@ -227,6 +227,20 @@ WARNING: Junit 4 is not supported in XP 8.0.0
 
 In XP8 the contextual repository and branch may return null if they are not set explicitly. Previously the default context was set with `com.enonic.cms.default` repository and `draft` branch.
 
+=== Roles
+
+The legacy role `role:cms.cm.app` (display name "Content Manager App") is deprecated. Fresh XP 8 installs no longer create this role, and it is no longer added to the default ACLs of content, issue, or archive root nodes when new projects are initialized.
+
+Existing installations upgrading from XP 7 keep the role definition and any pre-existing ACEs that reference it. Those entries are harmless but obsolete and should not be relied on going forward. Apps that previously granted `cms.cm.app` to a user or group should switch to the per-project role hierarchy that XP 8 manages per content project:
+
+* `role:cms.project.<name>.owner`
+* `role:cms.project.<name>.editor`
+* `role:cms.project.<name>.author`
+* `role:cms.project.<name>.contributor`
+* `role:cms.project.<name>.viewer`
+
+NOTE: Legacy dumps (model 8) imported into XP 8 are upgraded to model 9 automatically. During that upgrade, `cms.cm.app` is stripped from the legacy `com.enonic.cms.default` repository ACLs and replaced with the per-project role hierarchy. No manual action is required for that case.
+
 === Application Descriptor
 
 The `application.xml` descriptor must be converted to `application.yaml`.


### PR DESCRIPTION
## Summary

- Add a `=== Roles` subsection under "API Deprecations and Breaking Changes" in `docs/upgrade.adoc` documenting that the legacy `cms.cm.app` role is deprecated in XP 8: fresh installs no longer create it or add it to default ACLs on content/issue/archive roots, upgraded installs keep existing role and ACEs as harmless-but-obsolete, the legacy dump upgrader (model 8 → 9) strips it from `com.enonic.cms.default` automatically, and apps that previously granted `cms.cm.app` should switch to the per-project role hierarchy (`cms.project.<name>.{owner,editor,author,contributor,viewer}`).
- Drop the stale `role:cms.cm.app` entry from the `getMemberships` sample response in `docs/libraries/lib-auth.adoc` so readers don't think they should still grant a deprecated role; replaced it with `role:cms.project.default.editor` to keep the example pedagogically useful and show a current per-project role key.

## Context

Platform change: https://github.com/enonic/xp/issues/12023 — `cms.cm.app` is being marked `@Deprecated`, removed from `SecurityInitializer`'s role-creation list, and removed from default ACLs on newly initialized content/issue/archive roots.

## Test plan

- [ ] Spot-check rendering of the new `=== Roles` block in `docs/upgrade.adoc` (no underscore-containing identifiers — should render cleanly).
- [ ] Confirm `getMemberships` sample JSON in `docs/libraries/lib-auth.adoc` still parses as valid JS after the entry swap.
- [ ] No `docs/menu.json` update needed — only edits to existing pages.