### PR TITLE
Document idProviderConfig on lib-auth

### DIFF
--- a/docs/libraries/lib-auth.adoc
+++ b/docs/libraries/lib-auth.adoc
@@ -174,6 +174,7 @@ An object with the following keys and their values:
 | key | string | | ID provider key
 | displayName | string | | ID provider display name
 | description | string | <optional> | ID provider description
+| idProviderConfig | object | <optional> | Binds this provider to one application. Without it the provider is incomplete and login plumbing won't resolve back to an app.
 | permissions | object[] | <optional> | ID provider permissions
 |===
 
@@ -189,6 +190,20 @@ An object with the following keys and their values:
 | Name | Type | Attributes | Default | Description
 | principal | string | | | Principal key
 | access | string | | | Permission level: +READ+, +CREATE_USERS+, +WRITE_USERS+, +ID_PROVIDER_MANAGER+, +ADMINISTRATOR+
+!===
+
+[.lead]
+`idProviderConfig` properties
+
+[%header,cols="1%,1%,1%,1%,96%a"]
+[frame="topbot"]
+[grid="none"]
+[caption=""]
+.Properties
+!===
+| Name | Type | Attributes | Default | Description
+| applicationKey | string | | | Key of the application whose handlers serve requests for this provider.
+| config | object | <optional> | | Per-instance configuration tree passed to the bound application.
 !===
 
 [.lead]
@@ -208,6 +223,12 @@ const idProvider = createIdProvider({
     key: 'myIdProvider',
     displayName: 'My ID Provider',
     description: 'My ID provider description',
+    idProviderConfig: {
+        applicationKey: 'com.example.myidprovider',
+        config: {
+            // app-specific configuration
+        }
+    },
     permissions: [
         {
             principal: 'role:system.admin',
@@ -223,7 +244,13 @@ const idProvider = createIdProvider({
 ({
     key: "myIdProvider",
     displayName: "My ID Provider",
-    description: "My ID provider description"
+    description: "My ID provider description",
+    idProviderConfig: {
+        applicationKey: "com.example.myidprovider",
+        config: {
+            // app-specific configuration
+        }
+    }
 })
 ----
 
@@ -556,6 +583,51 @@ const config = getIdProviderConfig<{ field?: string }>();
 if (config) {
     log.info('Field value for the current ID provider config = %s', config.field);
 }
+----
+
+=== getIdProviders
+
+Returns all id providers configured on the system. Each entry's `idProviderConfig` is present only when the provider is bound to an application; incomplete providers come back without it.
+
+[.lead]
+Parameters
+
+None
+
+[.lead]
+Returns
+
+*object[]*: A list of ID providers.
+
+[.lead]
+Example
+
+.Retrieving all ID providers
+[source,typescript]
+----
+import {getIdProviders} from '/lib/xp/auth';
+
+const idProviders = getIdProviders();
+----
+
+.Sample response
+[source,js]
+----
+([
+    {
+        key: "system",
+        displayName: "System Id Provider"
+    },
+    {
+        key: "myIdProvider",
+        displayName: "My ID Provider",
+        description: "My ID provider description",
+        idProviderConfig: {
+            applicationKey: "com.example.myidprovider",
+            config: {}
+        }
+    }
+])
 ----
 
 === getMembers


### PR DESCRIPTION
## Summary

- Add `idProviderConfig` to the `createIdProvider` reference (new parameter row, properties subtable, updated TS example and sample response).
- Add a brand-new `=== getIdProviders` section between `=== getIdProviderConfig` and `=== getMembers`, mirroring the surrounding sections' shape.

Source PRs that introduced the JS API surface this documents:
- enonic/xp#12042 — `createIdProvider` accepts `idProviderConfig`; `getIdProviders` returns it per entry.
- enonic/xp#11990 — earlier addition of `getIdProviders`.

Out of scope (per xp#12042): `updateIdProvider` / `deleteIdProvider`.

## Test plan

- [ ] AsciiDoc renders cleanly (IDE preview or GitHub render of `docs/libraries/lib-auth.adoc`).
- [ ] New `idProviderConfig` row sits inside the existing parameter table, not orphaned.
- [ ] `=== getIdProviders` section appears alphabetically between `=== getIdProviderConfig` and `=== getMembers` and renders as a sibling, not nested.
- [ ] TS / JS code blocks render with syntax highlighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)