### PR TITLE
lib-project: document XP 8 API changes (xp#12043)

### DIFF
--- a/docs/libraries/lib-project.adoc
+++ b/docs/libraries/lib-project.adoc
@@ -239,8 +239,6 @@ const expected = {
 
 Deletes an existing Content Project and the project repository along with all the data inside.
 
-NOTE: Renamed from `delete` to avoid the JavaScript reserved word. The old `delete` export is still available for backward compatibility.
-
 NOTE: To delete a project, user must have either `system.admin` or `cms.admin` role.
 
 [.lead]

--- a/docs/libraries/lib-project.adoc
+++ b/docs/libraries/lib-project.adoc
@@ -465,8 +465,6 @@ const expected = {
 
 Toggles public/private READ access for an existing Content Project. This will modify permissions on ALL the content items inside the project repository by adding or removing READ access for `system.everyone`.
 
-NOTE: Renamed from `modifyReadAccess` in XP 8. The parameter shape flattened from `{readAccess: {public}}` to `{publicRead}`.
-
 NOTE: To modify READ access, user must have `Owner` permissions for the project, or either `system.admin` or `cms.admin` role.
 
 [.lead]

--- a/docs/libraries/lib-project.adoc
+++ b/docs/libraries/lib-project.adoc
@@ -119,13 +119,7 @@ Parameters
 ! role ! string ! Role id (one of `owner`, `editor`, `author`, `contributor`, `viewer`).
 ! principals ! string[] ! Array of principals.
 !===
-| readAccess | Object.<string, boolean> | | Read access settings.
-[stripes=none,cols="1,1,98"]
-!===
-! Name ! Type ! Description
-! public ! boolean ! Public read access (READ permissions for `system.everyone`).
-
-!===
+| publicRead | boolean | | `true` to grant READ permissions to `system.everyone`, `false` otherwise.
 |===
 
 [.lead]
@@ -146,9 +140,7 @@ try {
     const project = create({
         id: 'my-project',
         displayName: 'My Content Project',
-        readAccess: {
-            public: true
-        }
+        publicRead: true
     });
 } catch (e) {
     log.error('Failed to create a project: %s', e.message);
@@ -162,9 +154,7 @@ const expected = {
   id: 'my-project',
   displayName: 'My Content Project',
   permissions: {},
-  readAccess: {
-    public: true
-  }
+  publicRead: true
 }
 ----
 
@@ -197,9 +187,7 @@ const project = create({
                 b: 3.4
             }
         }],
-    readAccess: {
-        public: false
-    }
+    publicRead: false
 });
 ----
 
@@ -243,9 +231,7 @@ const expected = {
         'user:mystore:user5'
     ]
   },
-  readAccess: {
-    public: false
-  }
+  publicRead: false
 }
 ----
 
@@ -397,28 +383,23 @@ const expected = [{
 
 Modifies an existing Content Project.
 
+Pass an `editor` function that receives the current project, mutates fields on it, and returns it. Fields the editor doesn't touch are left unchanged. Setting `description`, `language`, or `siteConfig` to `null` clears them. `displayName` is required and cannot be cleared.
+
 NOTE: To modify a project, user must have `Owner` permissions for this project, or either `system.admin` or `cms.admin` role.
 
 [.lead]
 Parameters
 
-[%header,cols="1,1,1,97a"]
+[%header,cols="1,1,98a"]
 [frame="none"]
 [grid="none"]
 |===
-| Name | Type | Attributes | Description
-| id | string | | Unique project id (alpha-numeric characters and hyphens allowed).
-| displayName | string | <optional> | Project display name.
-| description | string | <optional> | Project description.
-| language | string | <optional> | Default project language.
-| siteConfig | Object.<string, Object>[] | <optional> | Applications (with optional configurations) to be assigned to the project.
-[stripes=none,cols="1,49,50"]
-!===
-! Name ! Type ! Description
-! applicationKey ! string ! Application key
-! config ! Object ! Application config json
-!===
+| Name | Type | Description
+| id | string | Unique project id (alpha-numeric characters and hyphens allowed).
+| editor | Function | Function that receives the editable project, mutates fields, and returns it.
 |===
+
+The editor's input has the same shape as a `Project` plus the editable fields `displayName`, `description`, `language`, and `siteConfig`.
 
 [.lead]
 Returns
@@ -436,21 +417,19 @@ import {modify} from '/lib/xp/project';
 
 const project = modify({
     id: 'my-project',
-    displayName: 'New project name',
-    description: 'New project description',
-    language: 'en',
-    siteConfig: [{
+    editor: (project) => {
+        project.displayName = 'New project name';
+        project.description = 'New project description';
+        project.language = 'en';
+        project.siteConfig = [{
             applicationKey: 'app1',
-            config: {
-                a: 'b'
-            }
-        } ,{
+            config: { a: 'b' }
+        }, {
             applicationKey: 'app2',
-            config: {
-                a: true,
-                b: 3.4
-            }
-        }],
+            config: { a: true, b: 3.4 }
+        }];
+        return project;
+    }
 });
 ----
 
@@ -478,40 +457,34 @@ const expected = {
         }
     ],
     permissions: {},
-    readAccess: {
-        public: true
-    }
+    publicRead: true
 }
 ----
 
-=== modifyReadAccess
+=== setPublicRead
 
 Toggles public/private READ access for an existing Content Project. This will modify permissions on ALL the content items inside the project repository by adding or removing READ access for `system.everyone`.
+
+NOTE: Renamed from `modifyReadAccess` in XP 8. The parameter shape flattened from `{readAccess: {public}}` to `{publicRead}`.
 
 NOTE: To modify READ access, user must have `Owner` permissions for the project, or either `system.admin` or `cms.admin` role.
 
 [.lead]
 Parameters
 
-[%header,cols="1,35,64a"]
+[%header,cols="1,1,98a"]
 [frame="none"]
 [grid="none"]
 |===
 | Name | Type | Description
 | id | string | Unique project id (alpha-numeric characters and hyphens allowed).
-| readAccess | Object.<string, boolean> | Read access settings.
-[stripes=none,cols="1,1,98"]
-!===
-! Name ! Type ! Description
-! public ! boolean ! Public read access (READ permissions for `system.everyone`).
-
-!===
+| publicRead | boolean | `true` to grant READ permissions to `system.everyone`, `false` otherwise.
 |===
 
 [.lead]
 Returns
 
-*Object* : Current state of public READ access.
+*boolean* : Resulting public-read state.
 
 
 [.lead]
@@ -520,24 +493,18 @@ Example
 .Set content project as not available for public READ access
 [source,typescript]
 ----
-import {modifyReadAccess} from '/lib/xp/project';
+import {setPublicRead} from '/lib/xp/project';
 
-const currentReadAccess = modifyReadAccess({
+const publicRead = setPublicRead({
     id: 'my-project',
-    readAccess: {
-        public: false
-    }
+    publicRead: false
 });
 ----
 
 .Sample response
 [source,typescript]
 ----
-const expected = {
-    readAccess: {
-        public: false
-    }
-}
+const expected = false;
 ----
 
 === removePermissions

--- a/docs/upgrade.adoc
+++ b/docs/upgrade.adoc
@@ -1037,6 +1037,8 @@ dependencies {
 
 === lib-content
 
+Reading the project's root content (path `/`) via `lib-content` (`get`, `getByPath`, etc.) now returns `null`. The root is reserved for the platform; use `lib-project` for project metadata (`get({id})`, `list()`) and create/move content under named paths only.
+
 `move` and `rename` methods are merged into a single `move` method.
 
 `setChildOrder` and `reorderChildren` methods are merged into a single `sort` method.
@@ -1081,6 +1083,41 @@ XP 8
 [source,typescript]
 ----
 import {deleteProject} from '/lib/xp/project';
+----
+
+**`readAccess: { public }` → `publicRead: boolean`.** `create({readAccess: {public: true}})` is now `create({publicRead: true})`. The `Project` shape returned by `get` / `list` / `create` carries `publicRead` instead of `readAccess.public`. The nested-object form has been removed entirely; there is no backward-compat shim.
+
+**`modifyReadAccess` → `setPublicRead`.** Same flat shape:
+
+[source,typescript]
+----
+// XP 7
+import {modifyReadAccess} from '/lib/xp/project';
+modifyReadAccess({id: 'p', readAccess: {public: true}});
+
+// XP 8
+import {setPublicRead} from '/lib/xp/project';
+setPublicRead({id: 'p', publicRead: true});
+----
+
+**`modify` now takes an `editor` function** instead of optional setter-style fields. Fields the editor doesn't touch are left unchanged; setting `description`, `language`, or `siteConfig` to `null` clears them. `displayName` cannot be cleared.
+
+[source,typescript]
+----
+// XP 7
+import {modify} from '/lib/xp/project';
+modify({id: 'p', displayName: 'New name', language: 'no'});
+
+// XP 8
+import {modify} from '/lib/xp/project';
+modify({
+    id: 'p',
+    editor: (project) => {
+        project.displayName = 'New name';
+        project.language = 'no';
+        return project;
+    }
+});
 ----
 
 === lib-repo


### PR DESCRIPTION
## Summary

[`enonic/xp#12043`](https://github.com/enonic/xp/pull/12043) (merged 2026-05-18) is a meaningful breaking change for lib-project and adds a root-content access restriction to lib-content. Updating the docs:

### `docs/upgrade.adoc`

- **lib-content:** new short note — reading the project's root content (path `/`) via `lib-content` (`get`, `getByPath`, …) now returns `null`. Use `lib-project` for project metadata.
- **lib-project:** extend the existing `delete → deleteProject` paragraph with three more breaking-change notes:
  - `readAccess: { public }` → `publicRead: boolean` (flat) on `create` params and on the `Project` return shape. No backward-compat shim.
  - `modifyReadAccess` renamed to `setPublicRead` (same flattening).
  - `modify` switched to an `editor`-function pattern; old setter-style fields are gone.

  Each entry has a tight XP 7 → XP 8 before/after TS snippet.

### `docs/libraries/lib-project.adoc`

- **`create`:** params table + both examples rewritten to use `publicRead: boolean`. Sample responses updated.
- **`modify`:** section rewritten around the editor-function shape; example uses mutate-and-return; sample response updated to `publicRead`.
- **`modifyReadAccess`** section renamed to **`setPublicRead`** with flat boolean parameter and boolean return. Cross-link `NOTE:` calls out the rename so old readers find it.

## Test plan

- [x] AsciiDoc preview renders cleanly; no stray `readAccess` references in the lib-project page (`grep readAccess docs/libraries/lib-project.adoc` → empty).
- [ ] CI green.