### PR TITLE
Document WebSocket HTTP session binding (xp#12116)

### DIFF
--- a/docs/web/code/websockets-5.ts
+++ b/docs/web/code/websockets-5.ts
@@ -1,0 +1,16 @@
+// Keep the session alive while the client is active, close the socket on logout
+exports.GET = (req) => {
+
+  if (!req.webSocket) {
+    return { status: 404 };
+  }
+
+  return {
+    webSocket: {
+      subProtocols: ['text'],
+      terminateOnSessionExit: true,   // close the socket when the session ends (default)
+      sessionAccess: true,            // inbound messages keep the session alive
+      sessionAccessThrottleMs: 30000  // refresh the session at most every 30 seconds
+    }
+  };
+};

--- a/docs/web/websocket.adoc
+++ b/docs/web/websocket.adoc
@@ -93,3 +93,47 @@ include::code/websockets-4.js[]
 
 The function runs synchronously during the handshake, before any `webSocketEvent` callback. It should be a pure function of the `origin` string; capture any per-request data with a closure inside the `GET` handler. A function that throws or returns a non-boolean rejects the upgrade.
 
+[#session-binding]
+== HTTP session binding
+
+A WebSocket starts as a regular HTTP request, and that request may run within an HTTP session — typically when the user is logged in. Once the socket is established, its traffic no longer passes through the HTTP layer, so out of the box the session and the socket would know nothing about each other. Three optional `webSocket` response parameters control how the two are bound:
+
+[cols="2,1,1,4", options="header"]
+|===
+| Parameter | Type | Default | Description
+
+| `terminateOnSessionExit`
+| boolean
+| `true`
+| Close the WebSocket when the HTTP session it was opened in ends
+
+| `sessionAccess`
+| boolean
+| `false`
+| Let inbound WebSocket messages refresh the HTTP session, keeping it alive
+
+| `sessionAccessThrottleMs`
+| number
+| `60000`
+| Minimum interval, in milliseconds, between session refreshes when `sessionAccess` is enabled
+|===
+
+[source,typescript]
+----
+include::code/websockets-5.ts[]
+----
+
+=== Closing on session end
+
+By default, a WebSocket opened within an HTTP session is closed when that session ends — whether through explicit logout (invalidation) or idle-timeout expiry. The socket is closed with code `1008` (policy violation) and reason `HTTP session ended`; the implementation receives the usual `close` event with `closeReason` `1008`. Set `terminateOnSessionExit: false` to let the socket outlive its session.
+
+If the upgrade request carries no HTTP session, there is nothing to bind, and the socket stays open regardless of this parameter.
+
+NOTE: Idle-expired sessions are invalidated by a periodic sweep, not at the exact moment the timeout elapses, so the close can lag the configured session timeout slightly. The sweep runs at one tenth of the session timeout, clamped between 10 seconds and 10 minutes.
+
+=== Keeping the session alive
+
+A user who only interacts through an open WebSocket generates no HTTP requests, so their session can idle out — and, with the default `terminateOnSessionExit`, take the socket down with it. Set `sessionAccess: true` to count inbound messages (client to server) as session activity: each message refreshes the session the socket was opened in. Messages pushed from the server to the client never count as activity.
+
+Refreshes are throttled to at most one per `sessionAccessThrottleMs` milliseconds (default `60000`); messages arriving within the throttle window are delivered normally but do not touch the session. `sessionAccess` works independently of `terminateOnSessionExit` — it refreshes the session even for a socket configured to outlive it.
+


### PR DESCRIPTION
Recreates the documentation for [enonic/xp#12119](https://github.com/enonic/xp/pull/12119) (issue enonic/xp#12116), which was lost before reaching this repo.

Adds an *HTTP session binding* section to `docs/web/websocket.adoc` covering the new `webSocket` response parameters, verified against the XP source:

- `terminateOnSessionExit` (default `true`) — the socket is closed with code `1008`, reason `HTTP session ended`, when the HTTP session it was opened in ends (logout or idle-timeout expiry); no-op when the upgrade request has no session.
- `sessionAccess` (default `false`) — inbound (client-to-server) messages refresh the HTTP session; server pushes never count.
- `sessionAccessThrottleMs` (default `60000`) — minimum interval between refreshes.

Also notes that idle expiry is detected by a periodic sweep (1/10 of the session timeout, clamped to [10 s, 10 min]), so the close can lag the timeout slightly. Includes a new TypeScript example (`websockets-5.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)